### PR TITLE
Improve SRA download

### DIFF
--- a/metaquest/__init__.py
+++ b/metaquest/__init__.py
@@ -5,7 +5,7 @@ MetaQuest helps users search through SRA datasets to find containment of specifi
 genomes and analyze associated metadata.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Andreas Sjödin"
 __email__ = "andreas.sjodin@gmail.com"
 

--- a/metaquest/cli/main.py
+++ b/metaquest/cli/main.py
@@ -341,7 +341,23 @@ def create_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Calculate number of accessions without downloading",
     )
+    parser_download_sra.add_argument(
+        "--force",
+        action="store_true",
+        help="Force redownload even if files exist",
+    )
+    parser_download_sra.add_argument(
+        "--max-retries",
+        type=int,
+        default=1,
+        help="Maximum number of retry attempts for failed downloads",
+    )
+    parser_download_sra.add_argument(
+        "--temp-folder",
+        help="Directory to use for fasterq-dump temporary files (must be writable)",
+    )
     parser_download_sra.set_defaults(func=download_sra_command)
+
 
     # Assemble datasets command
     parser_assemble_datasets = subparsers.add_parser(


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and robustness of the SRA data download process in the `metaquest` package. The key changes include updating the version, improving the download command, adding new command-line arguments, and enhancing the download logic to handle retries and temporary files more effectively.

Enhancements to SRA data download:

* [`metaquest/cli/commands.py`](diffhunk://#diff-ba346fa5bbdc12decb1b43e0f55282b54742de49098c34357eaa1a264401a3f8L286-R341): Updated the `download_sra_command` function to handle additional parameters (`force`, `max_retries`, `temp_folder`) and improve logging for both dry-run and actual download scenarios.
* [`metaquest/cli/main.py`](diffhunk://#diff-c96bfcb0ade0eb28c0def15fb6f9da7541cd83e0a0f7460399c04d75acd3f338R344-R361): Added new command-line arguments (`--force`, `--max-retries`, `--temp-folder`) to the `download_sra` command parser to support forced redownloads, retry attempts, and temporary file handling.

Improvements to download logic:

* [`metaquest/data/sra.py`](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bL21-R151): Modified the `download_accession` function to handle forced redownloads, use temporary folders for downloads, and return detailed status messages.
* [`metaquest/data/sra.py`](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bL82-R184): Enhanced the `download_sra` function to support retries for failed downloads, provide detailed download statistics, and improve logging of the download process. [[1]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bL82-R184) [[2]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bL143-R375)

Version update:

* [`metaquest/__init__.py`](diffhunk://#diff-84e9a7e1dbea6d39bea627648c4851c2342bc499b59408ec7c0c12468339e949L8-R8): Updated the package version from `0.3.0` to `0.3.1`.