### PR TITLE
Small lint fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     
     steps:
       - uses: actions/checkout@v4

--- a/metaquest/__init__.py
+++ b/metaquest/__init__.py
@@ -10,8 +10,6 @@ __author__ = "Andreas Sjödin"
 __email__ = "andreas.sjodin@gmail.com"
 
 # Import commonly used modules for easier access
-from metaquest.core.exceptions import MetaQuestError, ValidationError
-from metaquest.utils.config import get_config, set_config
 from metaquest.utils.logging import setup_logging
 
 # Initialize logging by default

--- a/metaquest/cli/commands.py
+++ b/metaquest/cli/commands.py
@@ -6,9 +6,7 @@ This module provides the implementation for all CLI commands.
 
 import argparse
 import logging
-import os
 from pathlib import Path
-from typing import Dict, Optional
 
 from metaquest.core.exceptions import MetaQuestError
 from metaquest.data.branchwater import (
@@ -24,7 +22,6 @@ from metaquest.processing.counts import count_metadata as dp_count_metadata
 from metaquest.data.metadata import (
     download_metadata as dp_download_metadata,
     parse_metadata as dp_parse_metadata,
-    check_metadata_attributes as dp_check_metadata_attributes,
 )
 from metaquest.data.sra import (
     download_sra as dp_download_sra,
@@ -307,7 +304,7 @@ def download_sra_command(args: argparse.Namespace) -> int:
                 if args.max_downloads:
                     logger.info(f"  Limited to {args.max_downloads} downloads")
         else:
-            logger.info(f"Download summary:")
+            logger.info("Download summary:")
             logger.info(
                 f"  Successfully downloaded: {download_stats['successful']} datasets"
             )

--- a/metaquest/cli/main.py
+++ b/metaquest/cli/main.py
@@ -358,7 +358,6 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parser_download_sra.set_defaults(func=download_sra_command)
 
-
     # Assemble datasets command
     parser_assemble_datasets = subparsers.add_parser(
         "assemble_datasets", help="Assemble datasets from fastq files"

--- a/metaquest/data/file_io.py
+++ b/metaquest/data/file_io.py
@@ -196,7 +196,7 @@ def process_files_in_directory(
     Raises:
         DataAccessError: If raise_errors is True and an error occurs
     """
-    results = {}
+    results: Dict[str, T] = {}
     directory_path = Path(directory)
 
     try:

--- a/metaquest/data/sra.py
+++ b/metaquest/data/sra.py
@@ -10,10 +10,9 @@ import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Union, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 from metaquest.core.exceptions import DataAccessError
-from metaquest.core.validation import validate_folder
 from metaquest.data.file_io import ensure_directory
 
 logger = logging.getLogger(__name__)
@@ -161,7 +160,7 @@ def download_sra(
     force: bool = False,
     max_retries: int = 1,
     temp_folder: Optional[Union[str, Path]] = None,
-) -> Dict[str, any]:
+) -> Dict[str, Any]:
     """
     Download multiple SRA datasets.
 

--- a/metaquest/plugins/base.py
+++ b/metaquest/plugins/base.py
@@ -193,6 +193,10 @@ def register_discovered_plugins(
             logger.warning(f"Failed to register plugin {plugin.get_name()}: {e}")
 
 
-# Global plugin registries for different plugin types
-format_registry = PluginRegistry()
-visualizer_registry = PluginRegistry()
+# Define a type variable for the Plugin type
+FormatPluginT = TypeVar("FormatPluginT", bound=Plugin)
+VisualizerPluginT = TypeVar("VisualizerPluginT", bound=Plugin)
+
+# Then change your registry definitions to:
+format_registry: PluginRegistry[Plugin] = PluginRegistry()
+visualizer_registry: PluginRegistry[Plugin] = PluginRegistry()

--- a/metaquest/plugins/formats/branchwater.py
+++ b/metaquest/plugins/formats/branchwater.py
@@ -52,7 +52,9 @@ class BranchWaterFormatPlugin(Plugin):
         return all(col in headers for col in cls.REQUIRED_COLS)
 
     @classmethod
-    def parse_file(cls, file_path: Union[str, Path], genome_id: str) -> List[Containment]:
+    def parse_file(
+        cls, file_path: Union[str, Path], genome_id: str
+    ) -> List[Containment]:
         """
         Parse a Branchwater format file and return containment data.
 
@@ -76,7 +78,9 @@ class BranchWaterFormatPlugin(Plugin):
                 # Validate headers
                 if not cls.validate_header(reader.fieldnames or []):
                     missing = [
-                        col for col in cls.REQUIRED_COLS if col not in (reader.fieldnames or [])
+                        col
+                        for col in cls.REQUIRED_COLS
+                        if col not in (reader.fieldnames or [])
                     ]
                     raise ValidationError(
                         f"Missing required columns in {file_path}: {', '.join(missing)}"
@@ -92,7 +96,9 @@ class BranchWaterFormatPlugin(Plugin):
                         continue
 
                     # Extract and validate containment value
-                    containment_value = validate_containment_value(row.get("containment", ""))
+                    containment_value = validate_containment_value(
+                        row.get("containment", "")
+                    )
                     if containment_value is None:
                         logger.warning(
                             f"Skipping row with invalid containment value for {accession} in {file_path}"
@@ -119,7 +125,9 @@ class BranchWaterFormatPlugin(Plugin):
         except Exception as e:
             if isinstance(e, ValidationError):
                 raise
-            raise ValidationError(f"Error parsing Branchwater file {file_path}: {str(e)}")
+            raise ValidationError(
+                f"Error parsing Branchwater file {file_path}: {str(e)}"
+            )
 
     @classmethod
     def extract_metadata(cls, containment: Containment) -> Optional[SRAMetadata]:
@@ -140,7 +148,9 @@ class BranchWaterFormatPlugin(Plugin):
         # Map known fields to metadata attributes
         for source_field, target_field in cls.METADATA_MAPPING.items():
             if source_field in containment.additional_data:
-                setattr(metadata, target_field, containment.additional_data[source_field])
+                setattr(
+                    metadata, target_field, containment.additional_data[source_field]
+                )
 
         # Add all other fields to the attributes dictionary
         for key, value in containment.additional_data.items():

--- a/metaquest/plugins/formats/mastiff.py
+++ b/metaquest/plugins/formats/mastiff.py
@@ -135,6 +135,6 @@ class MastiffFormatPlugin(Plugin):
         # Mastiff format doesn't include much metadata
         # Add all available fields to the attributes dictionary
         for key, value in containment.additional_data.items():
-            metadata.attributes[key] = value
+            metadata.attributes[key] = str(value)
 
         return metadata

--- a/metaquest/processing/containment.py
+++ b/metaquest/processing/containment.py
@@ -180,10 +180,14 @@ def filter_samples_by_containment(
                     f"Available genomes: {', '.join([col for col in summary_df.columns if col not in ('max_containment', 'max_containment_annotation')])}"
                 )
             filtered_df = summary_df[summary_df[genome_id] > threshold]
-            logger.info(f"Found {len(filtered_df)} samples with {genome_id} > {threshold}")
+            logger.info(
+                f"Found {len(filtered_df)} samples with {genome_id} > {threshold}"
+            )
         else:
             filtered_df = summary_df[summary_df["max_containment"] > threshold]
-            logger.info(f"Found {len(filtered_df)} samples with max_containment > {threshold}")
+            logger.info(
+                f"Found {len(filtered_df)} samples with max_containment > {threshold}"
+            )
 
         return filtered_df
 
@@ -242,7 +246,9 @@ def find_co_occurring_genomes(
             return pd.DataFrame()
 
         # Create co-occurrence matrix
-        cooccurrence_matrix = pd.DataFrame(index=frequent_genomes, columns=frequent_genomes)
+        cooccurrence_matrix = pd.DataFrame(
+            index=frequent_genomes, columns=frequent_genomes
+        )
 
         for i in frequent_genomes:
             for j in frequent_genomes:

--- a/metaquest/visualization/reporting.py
+++ b/metaquest/visualization/reporting.py
@@ -43,26 +43,6 @@ def generate_report(
     include_plots: bool = True,
     include_tables: bool = True,
 ) -> Union[str, Path]:
-    """
-    Generate a comprehensive report from analysis results.
-
-    Args:
-        title: Title for the report
-        summary_file: Path to the containment summary file
-        metadata_file: Path to the metadata file
-        metadata_counts_file: Path to the metadata counts file
-        output_file: Path to save the report
-        format: Report format ('pdf' or 'html')
-        threshold: Containment threshold for filtering
-        include_plots: Whether to include plots
-        include_tables: Whether to include tables
-
-    Returns:
-        Path to the generated report
-
-    Raises:
-        VisualizationError: If the report generation fails
-    """
     try:
         # Check format
         if format not in ("pdf", "html"):
@@ -108,6 +88,9 @@ def generate_report(
                 include_plots=include_plots,
                 include_tables=include_tables,
             )
+
+        # Add a default return to satisfy the type checker
+        return Path(output_file)  # This ensures a value is always returned
 
     except Exception as e:
         if isinstance(e, VisualizationError):
@@ -284,7 +267,9 @@ def _generate_pdf_report(
             # Create table data
             table_data = []
             for col, count in top_columns.items():
-                table_data.append([col, count, f"{count / len(metadata_data) * 100:.1f}%"])
+                table_data.append(
+                    [col, count, f"{count / len(metadata_data) * 100:.1f}%"]
+                )
 
             # Create table
             ax.table(
@@ -301,7 +286,9 @@ def _generate_pdf_report(
         # Metadata count plots
         if counts_data is not None and include_plots:
             try:
-                fig = plot_metadata_counts(counts_data, title="Top Categories", plot_type="bar")
+                fig = plot_metadata_counts(
+                    counts_data, title="Top Categories", plot_type="bar"
+                )
                 pdf.savefig(fig)
                 plt.close(fig)
 
@@ -335,7 +322,9 @@ def _generate_pdf_report(
                             top_genomes.append((col, len(top_samples)))
 
                     top_genomes.sort(key=lambda x: x[1], reverse=True)
-                    top_genome_cols = [g[0] for g in top_genomes[: min(20, len(top_genomes))]]
+                    top_genome_cols = [
+                        g[0] for g in top_genomes[: min(20, len(top_genomes))]
+                    ]
 
                     if len(top_genome_cols) > 1:
                         # Create heatmap of top genome correlations
@@ -381,7 +370,8 @@ def _generate_html_report(
     """
     if not JINJA2_AVAILABLE:
         raise VisualizationError(
-            "HTML report generation requires jinja2. " "Please install with 'pip install jinja2'"
+            "HTML report generation requires jinja2. "
+            "Please install with 'pip install jinja2'"
         )
 
     # Create output directory
@@ -427,7 +417,9 @@ def _generate_html_report(
             # Metadata counts plot if available
             if counts_data is not None:
                 try:
-                    fig = plot_metadata_counts(counts_data, title="Top Categories", plot_type="bar")
+                    fig = plot_metadata_counts(
+                        counts_data, title="Top Categories", plot_type="bar"
+                    )
                     counts_plot_file = images_dir / "metadata_counts.png"
                     fig.savefig(counts_plot_file, dpi=300, bbox_inches="tight")
                     plt.close(fig)
@@ -464,7 +456,9 @@ def _generate_html_report(
                             top_genomes.append((col, len(top_samples)))
 
                     top_genomes.sort(key=lambda x: x[1], reverse=True)
-                    top_genome_cols = [g[0] for g in top_genomes[: min(20, len(top_genomes))]]
+                    top_genome_cols = [
+                        g[0] for g in top_genomes[: min(20, len(top_genomes))]
+                    ]
 
                     if len(top_genome_cols) > 1:
                         # Create heatmap of top genome correlations
@@ -496,7 +490,9 @@ def _generate_html_report(
     # Summary statistics
     summary_stats = {
         "total_samples": len(summary_data),
-        "samples_above_threshold": len(summary_data[summary_data["max_containment"] > threshold]),
+        "samples_above_threshold": len(
+            summary_data[summary_data["max_containment"] > threshold]
+        ),
         "threshold": threshold,
     }
 


### PR DESCRIPTION
This pull request includes various updates and improvements to the `metaquest` project, focusing on code cleanup, type hinting, and minor functionality changes. The most important changes include updating the Python version matrix in the CI configuration, removing unused imports, adding type hints, and improving code readability by reformatting multiline statements.

CI configuration update:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL48-R48): Updated the Python version matrix to include Python 3.12 and removed Python 3.8.

Code cleanup and removal of unused imports:

* [`metaquest/__init__.py`](diffhunk://#diff-84e9a7e1dbea6d39bea627648c4851c2342bc499b59408ec7c0c12468339e949L13-L14): Removed unused imports for `MetaQuestError`, `ValidationError`, `get_config`, and `set_config`.
* [`metaquest/cli/commands.py`](diffhunk://#diff-ba346fa5bbdc12decb1b43e0f55282b54742de49098c34357eaa1a264401a3f8L9-L11): Removed unused imports for `os`, `Dict`, and `Optional`. [[1]](diffhunk://#diff-ba346fa5bbdc12decb1b43e0f55282b54742de49098c34357eaa1a264401a3f8L9-L11) [[2]](diffhunk://#diff-ba346fa5bbdc12decb1b43e0f55282b54742de49098c34357eaa1a264401a3f8L27)

Type hinting and type variable definitions:

* [`metaquest/data/file_io.py`](diffhunk://#diff-15b7c9f80aeaff10e6071de5a3945f8411cbd1a64bcf6efd46b03227fbbb53daL199-R199): Added type hint `Dict[str, T]` to the `results` variable.
* [`metaquest/data/sra.py`](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bL164-R163): Changed the return type hint from `Dict[str, any]` to `Dict[str, Any]`.
* [`metaquest/plugins/base.py`](diffhunk://#diff-047ed88c8d163bcd1195e372f085efee8a2c872e88f5139a1fc6dfc9398c0932L196-R202): Defined type variables `FormatPluginT` and `VisualizerPluginT` for the `PluginRegistry`.

Code readability improvements:

* [`metaquest/plugins/formats/branchwater.py`](diffhunk://#diff-be21d1fbcc0a7f8f40b229073c343182c282e9e297df6f1d009c1679e0edb78dL55-R57): Reformatted multiline statements for better readability. [[1]](diffhunk://#diff-be21d1fbcc0a7f8f40b229073c343182c282e9e297df6f1d009c1679e0edb78dL55-R57) [[2]](diffhunk://#diff-be21d1fbcc0a7f8f40b229073c343182c282e9e297df6f1d009c1679e0edb78dL79-R83) [[3]](diffhunk://#diff-be21d1fbcc0a7f8f40b229073c343182c282e9e297df6f1d009c1679e0edb78dL95-R101) [[4]](diffhunk://#diff-be21d1fbcc0a7f8f40b229073c343182c282e9e297df6f1d009c1679e0edb78dL122-R130) [[5]](diffhunk://#diff-be21d1fbcc0a7f8f40b229073c343182c282e9e297df6f1d009c1679e0edb78dL143-R153)
* [`metaquest/visualization/reporting.py`](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159R92-R94): Reformatted multiline statements and added a default return to satisfy the type checker. [[1]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159R92-R94) [[2]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159L287-R272) [[3]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159L304-R291) [[4]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159L338-R327) [[5]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159L384-R374) [[6]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159L430-R422) [[7]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159L467-R461) [[8]](diffhunk://#diff-34ac3079740baf129567fe6d9338a6874ddf956376f1e40dfb817e1a94c55159L499-R495)