### PR TITLE
Add blacklist

### DIFF
--- a/metaquest/cli/commands.py
+++ b/metaquest/cli/commands.py
@@ -290,6 +290,7 @@ def download_sra_command(args: argparse.Namespace) -> int:
             force=args.force,
             max_retries=args.max_retries,
             temp_folder=args.temp_folder,
+            blacklist=args.blacklist,
         )
 
         if args.dry_run:
@@ -299,6 +300,10 @@ def download_sra_command(args: argparse.Namespace) -> int:
             logger.info(
                 f"  {download_stats['already_downloaded']} datasets would be skipped (already downloaded)"
             )
+            if 'blacklisted' in download_stats and download_stats['blacklisted'] > 0:
+                logger.info(
+                    f"  {download_stats['blacklisted']} datasets would be skipped (blacklisted)"
+                )
             if "to_download" in download_stats and download_stats["to_download"] > 0:
                 logger.info(f"  Output folder would be: {args.fastq_folder}")
                 if args.max_downloads:
@@ -312,6 +317,10 @@ def download_sra_command(args: argparse.Namespace) -> int:
             logger.info(
                 f"  Already downloaded: {download_stats['already_downloaded']} datasets"
             )
+            if 'blacklisted' in download_stats and download_stats['blacklisted'] > 0:
+                logger.info(
+                    f"  Blacklisted: {download_stats['blacklisted']} datasets"
+                )
             logger.info(f"  Total processed: {download_stats['total']} datasets")
 
         # Return error if there were failed downloads

--- a/metaquest/cli/main.py
+++ b/metaquest/cli/main.py
@@ -356,6 +356,11 @@ def create_parser() -> argparse.ArgumentParser:
         "--temp-folder",
         help="Directory to use for fasterq-dump temporary files (must be writable)",
     )
+    parser_download_sra.add_argument(
+        "--blacklist",
+        nargs="+",
+        help="One or more files containing blacklisted accessions, one per line",
+    )
     parser_download_sra.set_defaults(func=download_sra_command)
 
     # Assemble datasets command


### PR DESCRIPTION
This pull request introduces a new feature to handle blacklisted accessions in the SRA download process. The changes include adding a new argument for blacklist files, updating the download logic to skip blacklisted accessions, and logging the details of blacklisted accessions.

Key changes include:

### New Argument for Blacklist Files:
* Added `--blacklist` argument to `create_parser` in `metaquest/cli/main.py` to specify one or more files containing blacklisted accessions.

### Updates to Download Logic:
* Modified `download_sra_command` in `metaquest/cli/commands.py` to handle the new blacklist argument and log blacklisted accessions during dry-run and actual download. [[1]](diffhunk://#diff-ba346fa5bbdc12decb1b43e0f55282b54742de49098c34357eaa1a264401a3f8R293) [[2]](diffhunk://#diff-ba346fa5bbdc12decb1b43e0f55282b54742de49098c34357eaa1a264401a3f8R303-R306) [[3]](diffhunk://#diff-ba346fa5bbdc12decb1b43e0f55282b54742de49098c34357eaa1a264401a3f8R320-R323)
* Added `_read_blacklist_files` function in `metaquest/data/sra.py` to read accessions from blacklist files.
* Updated `_check_existing_downloads` function in `metaquest/data/sra.py` to check for blacklisted accessions and return them separately. [[1]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bL203-R263) [[2]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bL230-R275)
* Modified `download_sra` function in `metaquest/data/sra.py` to integrate blacklist handling and update download statistics accordingly. [[1]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bR426) [[2]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bR441) [[3]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bR468-R479) [[4]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bR489) [[5]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bR550) [[6]](diffhunk://#diff-7ecb22c004e72ecc6ad64f4e21096abad89f772b32e9a04deaa7d5c47498217bR564)