### PR TITLE
Decompose the four remaining C-15 complexity hotspots

### DIFF
--- a/metaquest/cli/commands/sra.py
+++ b/metaquest/cli/commands/sra.py
@@ -99,9 +99,7 @@ class DownloadSraCommand(BaseCommand):
 
     def _report_failed_downloads(self, args: argparse.Namespace, stats: dict) -> None:
         """Warn about failures and write the failed accessions to a retry file."""
-        self.logger.warning(
-            "Some downloads failed. Use --force to retry or --max-retries to enable automatic retry."
-        )
+        self.logger.warning("Some downloads failed. Use --force to retry or --max-retries to enable automatic retry.")
         if not stats.get("failed_accessions"):
             return
         failed_file = Path(args.fastq_folder) / "failed_accessions.txt"

--- a/metaquest/cli/commands/sra.py
+++ b/metaquest/cli/commands/sra.py
@@ -76,6 +76,45 @@ class DownloadSraCommand(BaseCommand):
             help="One or more files containing blacklisted accessions, one per line",
         )
 
+    def _log_dry_run_summary(self, args: argparse.Namespace, stats: dict) -> None:
+        """Log the summary for a dry run."""
+        self.logger.info(f"Dry run: would download {stats['to_download']} of {stats['total']} datasets")
+        self.logger.info(f"  {stats['already_downloaded']} datasets would be skipped (already downloaded)")
+        if stats.get("blacklisted", 0) > 0:
+            self.logger.info(f"  {stats['blacklisted']} datasets would be skipped (blacklisted)")
+        if stats.get("to_download", 0) > 0:
+            self.logger.info(f"  Output folder would be: {args.fastq_folder}")
+            if args.max_downloads:
+                self.logger.info(f"  Limited to {args.max_downloads} downloads")
+
+    def _log_download_summary(self, stats: dict) -> None:
+        """Log the summary for a completed download run."""
+        self.logger.info("Download summary:")
+        self.logger.info(f"  Successfully downloaded: {stats['successful']} datasets")
+        self.logger.info(f"  Failed downloads: {stats['failed']} datasets")
+        self.logger.info(f"  Already downloaded: {stats['already_downloaded']} datasets")
+        if stats.get("blacklisted", 0) > 0:
+            self.logger.info(f"  Blacklisted: {stats['blacklisted']} datasets")
+        self.logger.info(f"  Total processed: {stats['total']} datasets")
+
+    def _report_failed_downloads(self, args: argparse.Namespace, stats: dict) -> None:
+        """Warn about failures and write the failed accessions to a retry file."""
+        self.logger.warning(
+            "Some downloads failed. Use --force to retry or --max-retries to enable automatic retry."
+        )
+        if not stats.get("failed_accessions"):
+            return
+        failed_file = Path(args.fastq_folder) / "failed_accessions.txt"
+        with open(failed_file, "w") as f:
+            for acc in stats["failed_accessions"]:
+                f.write(f"{acc}\n")
+        self.logger.info(f"Failed accessions written to {failed_file}")
+        self.logger.info(
+            f"To retry only failed accessions: metaquest download_sra "
+            f"--accessions-file {failed_file} "
+            f"--fastq-folder {args.fastq_folder}"
+        )
+
     def execute(self, args: argparse.Namespace) -> int:
         try:
             download_stats = download_sra(
@@ -92,45 +131,13 @@ class DownloadSraCommand(BaseCommand):
             )
 
             if args.dry_run:
-                self.logger.info(
-                    f"Dry run: would download {download_stats['to_download']} of {download_stats['total']} datasets"
-                )
-                self.logger.info(
-                    f"  {download_stats['already_downloaded']} datasets would be skipped (already downloaded)"
-                )
-                if "blacklisted" in download_stats and download_stats["blacklisted"] > 0:
-                    self.logger.info(f"  {download_stats['blacklisted']} datasets would be skipped (blacklisted)")
-                if "to_download" in download_stats and download_stats["to_download"] > 0:
-                    self.logger.info(f"  Output folder would be: {args.fastq_folder}")
-                    if args.max_downloads:
-                        self.logger.info(f"  Limited to {args.max_downloads} downloads")
+                self._log_dry_run_summary(args, download_stats)
             else:
-                self.logger.info("Download summary:")
-                self.logger.info(f"  Successfully downloaded: {download_stats['successful']} datasets")
-                self.logger.info(f"  Failed downloads: {download_stats['failed']} datasets")
-                self.logger.info(f"  Already downloaded: {download_stats['already_downloaded']} datasets")
-                if "blacklisted" in download_stats and download_stats["blacklisted"] > 0:
-                    self.logger.info(f"  Blacklisted: {download_stats['blacklisted']} datasets")
-                self.logger.info(f"  Total processed: {download_stats['total']} datasets")
+                self._log_download_summary(download_stats)
 
-            # Return error if there were failed downloads
             if not args.dry_run and download_stats["failed"] > 0:
-                self.logger.warning(
-                    "Some downloads failed. Use --force to retry or --max-retries to enable automatic retry."
-                )
-                if "failed_accessions" in download_stats and download_stats["failed_accessions"]:
-                    # Write failed accessions to file for easier retry
-                    failed_file = Path(args.fastq_folder) / "failed_accessions.txt"
-                    with open(failed_file, "w") as f:
-                        for acc in download_stats["failed_accessions"]:
-                            f.write(f"{acc}\n")
-                    self.logger.info(f"Failed accessions written to {failed_file}")
-                    self.logger.info(
-                        f"To retry only failed accessions: metaquest download_sra "
-                        f"--accessions-file {failed_file} "
-                        f"--fastq-folder {args.fastq_folder}"
-                    )
-                return 1  # Return error code
+                self._report_failed_downloads(args, download_stats)
+                return 1
 
             return 0
 

--- a/metaquest/cli/commands/sra_intelligent.py
+++ b/metaquest/cli/commands/sra_intelligent.py
@@ -607,6 +607,55 @@ class SRAComparativeAnalysisCommand(BaseCommand):
             print(f"Invalid JSON in groups file: {e}")
             return {}
 
+    @staticmethod
+    def _print_group_summaries(groups, comparison) -> None:
+        """Print per-group dataset counts and available summary statistics."""
+        print("\nComparative Analysis Results:")
+        print("=" * 40)
+        for group_name, col_stats in comparison.summary_statistics.items():
+            print(f"\n{group_name}:")
+            print(f"  Datasets: {len(groups.get(group_name, []))}")
+            gc_stats = col_stats.get("gc_content")
+            if gc_stats:
+                print(f"  Avg GC content: {gc_stats['mean']:.1%}")
+            length_stats = col_stats.get("avg_read_length")
+            if length_stats:
+                print(f"  Avg read length: {length_stats['mean']:.1f}")
+            reads_stats = col_stats.get("total_reads")
+            if reads_stats:
+                print(f"  Mean total reads: {reads_stats['mean']:,.0f}")
+
+    @staticmethod
+    def _print_statistical_tests(comparison) -> None:
+        """Print statistical test results, marking significant ones."""
+        if not comparison.statistical_tests:
+            return
+        print("\nStatistical Tests:")
+        print("-" * 20)
+        for test_name, result in comparison.statistical_tests.items():
+            p_value = result.get("p_value", 1.0)
+            significant = p_value < 0.05
+            print(f"{test_name}: p={p_value:.4f} {'*' if significant else ''}")
+
+    @staticmethod
+    def _save_comparison_results(output_dir, groups, comparison) -> Path:
+        """Write the comparison results as JSON and return the output path."""
+        significant_differences = [col for col, test in comparison.statistical_tests.items() if test.get("significant")]
+        results_file = output_dir / "comparative_analysis.json"
+        with open(results_file, "w") as results_f:
+            json.dump(
+                {
+                    "groups": groups,
+                    "summary_statistics": comparison.summary_statistics,
+                    "statistical_tests": comparison.statistical_tests,
+                    "significant_differences": significant_differences,
+                    "outlier_datasets": comparison.outlier_datasets,
+                },
+                results_f,
+                indent=2,
+            )
+        return results_file
+
     def execute(self, args):
         try:
             # Load groups
@@ -626,57 +675,14 @@ class SRAComparativeAnalysisCommand(BaseCommand):
             output_dir = Path(args.output_dir)
             output_dir.mkdir(exist_ok=True)
 
-            analyzer = SRADatasetAnalyzer()
-
             print("\nPerforming comparative analysis...")
+            comparison = SRADatasetAnalyzer().compare_datasets(groups)
 
-            # Run comparative analysis
-            comparison = analyzer.compare_datasets(groups)
+            self._print_group_summaries(groups, comparison)
+            if args.statistical_tests:
+                self._print_statistical_tests(comparison)
 
-            # Print summary results
-            print("\nComparative Analysis Results:")
-            print("=" * 40)
-
-            for group_name, col_stats in comparison.summary_statistics.items():
-                print(f"\n{group_name}:")
-                print(f"  Datasets: {len(groups.get(group_name, []))}")
-                gc_stats = col_stats.get("gc_content")
-                if gc_stats:
-                    print(f"  Avg GC content: {gc_stats['mean']:.1%}")
-                length_stats = col_stats.get("avg_read_length")
-                if length_stats:
-                    print(f"  Avg read length: {length_stats['mean']:.1f}")
-                reads_stats = col_stats.get("total_reads")
-                if reads_stats:
-                    print(f"  Mean total reads: {reads_stats['mean']:,.0f}")
-
-            # Statistical tests results
-            if args.statistical_tests and comparison.statistical_tests:
-                print("\nStatistical Tests:")
-                print("-" * 20)
-                for test_name, result in comparison.statistical_tests.items():
-                    p_value = result.get("p_value", 1.0)
-                    significant = p_value < 0.05
-                    print(f"{test_name}: p={p_value:.4f} {'*' if significant else ''}")
-
-            # Save detailed results
-            significant_differences = [
-                col for col, test in comparison.statistical_tests.items() if test.get("significant")
-            ]
-            results_file = output_dir / "comparative_analysis.json"
-            with open(results_file, "w") as results_f:
-                json.dump(
-                    {
-                        "groups": groups,
-                        "summary_statistics": comparison.summary_statistics,
-                        "statistical_tests": comparison.statistical_tests,
-                        "significant_differences": significant_differences,
-                        "outlier_datasets": comparison.outlier_datasets,
-                    },
-                    results_f,
-                    indent=2,
-                )
-
+            results_file = self._save_comparison_results(output_dir, groups, comparison)
             print(f"\nDetailed results saved to: {results_file}")
 
             # Generate HTML report

--- a/metaquest/data/sra.py
+++ b/metaquest/data/sra.py
@@ -444,6 +444,58 @@ def _execute_parallel_downloads(
     return _process_download_results(futures_results, accessions, download_results, failed_accessions)
 
 
+def _resolve_fastq_path(fastq_folder: Union[str, Path], dry_run: bool) -> Path:
+    """Return the FASTQ output path, creating it unless in dry-run mode.
+
+    In dry-run mode the folder is not created, but an existing non-directory
+    at that location is still rejected.
+    """
+    fastq_path = Path(fastq_folder)
+    if dry_run:
+        if fastq_path.exists() and not fastq_path.is_dir():
+            raise DataAccessError(f"{fastq_folder} exists but is not a directory")
+        logger.info(f"Dry run mode: Would use {fastq_path} for downloads")
+        return fastq_path
+    return ensure_directory(fastq_folder)
+
+
+def _download_with_retries(
+    accessions_to_download, fastq_path, num_threads, max_workers, force, temp_folder, max_retries
+) -> Tuple[int, int, List[str], Dict[str, Any]]:
+    """Run the parallel downloads and optional retry pass.
+
+    Returns (successful_count, failed_count, failed_accessions, download_results).
+    """
+    failed_accessions: list = []
+    download_results: dict = {}
+    successful_count, failed_count = _execute_parallel_downloads(
+        accessions_to_download,
+        fastq_path,
+        num_threads,
+        max_workers,
+        force,
+        temp_folder,
+        download_results,
+        failed_accessions,
+    )
+
+    if max_retries > 0 and failed_accessions:
+        retried_successful, failed_accessions = _retry_failed_downloads(
+            failed_accessions,
+            max_retries,
+            fastq_path,
+            num_threads,
+            temp_folder,
+            download_results,
+        )
+        successful_count += retried_successful
+        failed_count -= retried_successful
+        if retried_successful > 0:
+            logger.info(f"Successfully downloaded {retried_successful} accessions on retry")
+
+    return successful_count, failed_count, failed_accessions, download_results
+
+
 def download_sra(
     fastq_folder: Union[str, Path],
     accessions_file: Union[str, Path],
@@ -479,16 +531,7 @@ def download_sra(
     """
     try:
         # Handle the output folder based on dry run status
-        fastq_path = Path(fastq_folder)
-
-        if dry_run:
-            # In dry-run mode, don't create folders
-            if fastq_path.exists() and not fastq_path.is_dir():
-                raise DataAccessError(f"{fastq_folder} exists but is not a directory")
-            logger.info(f"Dry run mode: Would use {fastq_path} for downloads")
-        else:
-            # Normal mode - ensure the directory exists
-            fastq_path = ensure_directory(fastq_folder)
+        fastq_path = _resolve_fastq_path(fastq_folder, dry_run)
 
         # Read accessions from file
         with open(accessions_file, "r") as f:
@@ -526,36 +569,10 @@ def download_sra(
             logger.info(f"Limiting to {max_downloads} downloads")
             accessions_to_download = accessions_to_download[:max_downloads]
 
-        # Download accessions in parallel
-        failed_accessions: list = []
-        download_results: dict = {}
-        successful_count, failed_count = _execute_parallel_downloads(
-            accessions_to_download,
-            fastq_path,
-            num_threads,
-            max_workers,
-            force,
-            temp_folder,
-            download_results,
-            failed_accessions,
+        # Download accessions in parallel, with an optional retry pass
+        successful_count, failed_count, failed_accessions, download_results = _download_with_retries(
+            accessions_to_download, fastq_path, num_threads, max_workers, force, temp_folder, max_retries
         )
-
-        # Retry failed downloads if requested
-        if max_retries > 0 and failed_accessions:
-            retried_successful, failed_accessions = _retry_failed_downloads(
-                failed_accessions,
-                max_retries,
-                fastq_path,
-                num_threads,
-                temp_folder,
-                download_results,
-            )
-
-            successful_count += retried_successful
-            failed_count -= retried_successful
-
-            if retried_successful > 0:
-                logger.info(f"Successfully downloaded {retried_successful} accessions on retry")
 
         # Log final summary
         logger.info("Download summary:")

--- a/metaquest/visualization/reporting.py
+++ b/metaquest/visualization/reporting.py
@@ -494,9 +494,7 @@ def _add_containment_plot_files(summary_data, images_dir, plot_files):
         ("histogram", "Containment Histogram", "containment_histogram.png", "hist_plot"),
     )
     for plot_type, title, filename, key in plots:
-        fig = plot_containment(
-            summary_data, column="max_containment", title=title, plot_type=plot_type, threshold=0
-        )
+        fig = plot_containment(summary_data, column="max_containment", title=title, plot_type=plot_type, threshold=0)
         rel = _save_report_fig(fig, images_dir, filename)
         if rel:
             plot_files[key] = rel

--- a/metaquest/visualization/reporting.py
+++ b/metaquest/visualization/reporting.py
@@ -263,25 +263,11 @@ def _add_correlation_heatmap(pdf, summary_data, threshold):
     """
     fig = None
     try:
-        # Get top 20 genomes by max containment
-        genome_columns = _get_genome_columns(summary_data)
-
-        if len(genome_columns) > 1:
-            top_genomes = []
-            for col in genome_columns:
-                top_samples = summary_data[summary_data[col] > threshold]
-                if not top_samples.empty:
-                    top_genomes.append((col, len(top_samples)))
-
-            top_genomes.sort(key=lambda x: x[1], reverse=True)
-            top_genome_cols = [g[0] for g in top_genomes[: min(20, len(top_genomes))]]
-
-            if len(top_genome_cols) > 1:
-                # Create heatmap of top genome correlations
-                correlation_matrix = summary_data[top_genome_cols].corr()
-
-                fig = plot_correlation_matrix(correlation_matrix, title="Genome Correlation Matrix")
-                pdf.savefig(fig)
+        top_genome_cols = _top_correlated_genome_columns(summary_data, threshold)
+        if len(top_genome_cols) > 1:
+            correlation_matrix = summary_data[top_genome_cols].corr()
+            fig = plot_correlation_matrix(correlation_matrix, title="Genome Correlation Matrix")
+            pdf.savefig(fig)
     except Exception as e:
         logger.warning(f"Error generating heatmap: {e}")
     finally:
@@ -473,6 +459,79 @@ def _prepare_template_data(
     return template_data
 
 
+def _save_report_fig(fig, images_dir, filename):
+    """Save a figure under images_dir and return its 'images/<filename>' path, or None."""
+    if fig is None:
+        return None
+    fig.savefig(images_dir / filename, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    return f"images/{filename}"
+
+
+def _top_correlated_genome_columns(summary_data, threshold, limit=20):
+    """Return up to `limit` genome columns ranked by sample count above threshold.
+
+    Returns an empty list when there are one or zero genome columns to correlate.
+    """
+    genome_columns = _get_genome_columns(summary_data)
+    if len(genome_columns) <= 1:
+        return []
+
+    ranked = []
+    for col in genome_columns:
+        above = summary_data[summary_data[col] > threshold]
+        if not above.empty:
+            ranked.append((col, len(above)))
+
+    ranked.sort(key=lambda x: x[1], reverse=True)
+    return [col for col, _ in ranked[:limit]]
+
+
+def _add_containment_plot_files(summary_data, images_dir, plot_files):
+    """Add the containment rank and histogram plots to plot_files."""
+    plots = (
+        ("rank", "Containment Rank Plot", "containment_rank.png", "rank_plot"),
+        ("histogram", "Containment Histogram", "containment_histogram.png", "hist_plot"),
+    )
+    for plot_type, title, filename, key in plots:
+        fig = plot_containment(
+            summary_data, column="max_containment", title=title, plot_type=plot_type, threshold=0
+        )
+        rel = _save_report_fig(fig, images_dir, filename)
+        if rel:
+            plot_files[key] = rel
+
+
+def _add_metadata_count_plot_files(counts_data, images_dir, plot_files):
+    """Add the metadata bar and pie plots to plot_files; log and skip on failure."""
+    try:
+        fig = plot_metadata_counts(counts_data, title="Top Categories", plot_type="bar")
+        rel = _save_report_fig(fig, images_dir, "metadata_counts.png")
+        if rel:
+            plot_files["counts_plot"] = rel
+
+        fig = plot_metadata_counts(counts_data.head(8), title="Top Categories (Pie Chart)", plot_type="pie")
+        rel = _save_report_fig(fig, images_dir, "metadata_pie.png")
+        if rel:
+            plot_files["pie_plot"] = rel
+    except Exception as e:
+        logger.warning(f"Error generating metadata count plots: {e}")
+
+
+def _add_correlation_plot_file(summary_data, threshold, images_dir, plot_files):
+    """Add the top-genome correlation heatmap to plot_files; log and skip on failure."""
+    try:
+        top_genome_cols = _top_correlated_genome_columns(summary_data, threshold)
+        if len(top_genome_cols) > 1:
+            correlation_matrix = summary_data[top_genome_cols].corr()
+            fig = plot_correlation_matrix(correlation_matrix, title="Genome Correlation Matrix")
+            rel = _save_report_fig(fig, images_dir, "genome_correlation.png")
+            if rel:
+                plot_files["heatmap_plot"] = rel
+    except Exception as e:
+        logger.warning(f"Error generating heatmap: {e}")
+
+
 def _generate_plots_for_html(summary_data, counts_data, threshold, images_dir):
     """
     Generate plots for HTML report.
@@ -486,88 +545,13 @@ def _generate_plots_for_html(summary_data, counts_data, threshold, images_dir):
     Returns:
         Dictionary of plot file paths
     """
-    plot_files = {}
+    plot_files: dict = {}
 
     try:
-        # Containment rank plot
-        fig = plot_containment(
-            summary_data,
-            column="max_containment",
-            title="Containment Rank Plot",
-            plot_type="rank",
-            threshold=0,
-        )
-        rank_plot_file = images_dir / "containment_rank.png"
-        assert fig is not None
-        fig.savefig(rank_plot_file, dpi=300, bbox_inches="tight")
-        plt.close(fig)
-        plot_files["rank_plot"] = "images/containment_rank.png"
-
-        # Containment histogram
-        fig = plot_containment(
-            summary_data,
-            column="max_containment",
-            title="Containment Histogram",
-            plot_type="histogram",
-            threshold=0,
-        )
-        hist_plot_file = images_dir / "containment_histogram.png"
-        assert fig is not None
-        fig.savefig(hist_plot_file, dpi=300, bbox_inches="tight")
-        plt.close(fig)
-        plot_files["hist_plot"] = "images/containment_histogram.png"
-
-        # Metadata counts plot if available
+        _add_containment_plot_files(summary_data, images_dir, plot_files)
         if counts_data is not None:
-            try:
-                fig = plot_metadata_counts(counts_data, title="Top Categories", plot_type="bar")
-                counts_plot_file = images_dir / "metadata_counts.png"
-                assert fig is not None
-                fig.savefig(counts_plot_file, dpi=300, bbox_inches="tight")
-                plt.close(fig)
-                plot_files["counts_plot"] = "images/metadata_counts.png"
-
-                # Pie chart
-                fig = plot_metadata_counts(
-                    counts_data.head(8),
-                    title="Top Categories (Pie Chart)",
-                    plot_type="pie",
-                )
-                pie_plot_file = images_dir / "metadata_pie.png"
-                assert fig is not None
-                fig.savefig(pie_plot_file, dpi=300, bbox_inches="tight")
-                plt.close(fig)
-                plot_files["pie_plot"] = "images/metadata_pie.png"
-            except Exception as e:
-                logger.warning(f"Error generating metadata count plots: {e}")
-
-        # Genome correlation heatmap
-        try:
-            # Get top 20 genomes by max containment
-            genome_columns = _get_genome_columns(summary_data)
-
-            if len(genome_columns) > 1:
-                top_genomes = []
-                for col in genome_columns:
-                    top_samples = summary_data[summary_data[col] > threshold]
-                    if not top_samples.empty:
-                        top_genomes.append((col, len(top_samples)))
-
-                top_genomes.sort(key=lambda x: x[1], reverse=True)
-                top_genome_cols = [g[0] for g in top_genomes[: min(20, len(top_genomes))]]
-
-                if len(top_genome_cols) > 1:
-                    # Create heatmap of top genome correlations
-                    correlation_matrix = summary_data[top_genome_cols].corr()
-
-                    fig = plot_correlation_matrix(correlation_matrix, title="Genome Correlation Matrix")
-                    heatmap_file = images_dir / "genome_correlation.png"
-                    assert fig is not None
-                    fig.savefig(heatmap_file, dpi=300, bbox_inches="tight")
-                    plt.close(fig)
-                    plot_files["heatmap_plot"] = "images/genome_correlation.png"
-        except Exception as e:
-            logger.warning(f"Error generating heatmap: {e}")
+            _add_metadata_count_plot_files(counts_data, images_dir, plot_files)
+        _add_correlation_plot_file(summary_data, threshold, images_dir, plot_files)
     except Exception as e:
         logger.warning(f"Error generating plots: {e}")
 


### PR DESCRIPTION
## Summary

Follow-up to #30, on its own branch to keep the diffs focused. Decomposes the four functions still at cyclomatic-complexity rank C(15) into small, single-purpose helpers. Behavior is unchanged throughout; each change is verified by the existing tests.

| Function | Before | After |
|---|---|---|
| `visualization/reporting.py::_generate_plots_for_html` | C (15) | **A (3)** |
| `data/sra.py::download_sra` | C (15) | **B (9)** |
| `cli/commands/sra.py::DownloadSraCommand.execute` | C (15) | **A (5)** |
| `cli/commands/sra_intelligent.py::SRAComparativeAnalysisCommand.execute` | C (15) | **B (6)** |

## What changed

- **`_generate_plots_for_html`**: extracted `_save_report_fig`, `_add_containment_plot_files`, `_add_metadata_count_plot_files`, and `_add_correlation_plot_file`; also extracted `_top_correlated_genome_columns` and reused it in the PDF path's `_add_correlation_heatmap`, removing duplicated genome-ranking logic.
- **`download_sra`**: extracted `_resolve_fastq_path` (dry-run vs ensure-directory) and `_download_with_retries` (parallel download + optional retry pass).
- **`DownloadSraCommand.execute`**: extracted `_log_dry_run_summary`, `_log_download_summary`, and `_report_failed_downloads`.
- **`SRAComparativeAnalysisCommand.execute`**: extracted `_print_group_summaries`, `_print_statistical_tests`, and `_save_comparison_results`.

The final commit re-applies Black to two files where the helper extraction hand-wrapped calls that Black collapses.

## Verification

- Full suite: **1190 passed**
- `make check` green (Black, flake8, mypy, the CDN guard, and the radon complexity ceiling)
- No function at rank C(15) or worse remains (worst is now C-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)