### PR TITLE
Decompose the five C-14 complexity hotspots

### DIFF
--- a/metaquest/data/sra_metadata.py
+++ b/metaquest/data/sra_metadata.py
@@ -10,7 +10,7 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import requests
@@ -512,6 +512,52 @@ def save_metadata_report(metadata: Dict[str, SRADatasetInfo], output_file: Union
     logger.info(f"Metadata report saved to {output_file}")
 
 
+def _dataset_stats_row(acc_dir: Path) -> Optional[Dict[str, Any]]:
+    """Compute a statistics row for one accession directory, or None if unavailable."""
+    logger.info(f"Processing {acc_dir.name}")
+
+    fastq_files = list(acc_dir.glob("*.fastq*"))
+    if not fastq_files:
+        logger.warning(f"No FASTQ files found in {acc_dir}")
+        return None
+
+    try:
+        stats = calculate_read_statistics(fastq_files)
+    except Exception as e:
+        logger.error(f"Failed to calculate statistics for {acc_dir.name}: {e}")
+        return None
+
+    layout = "PAIRED" if any("_2" in f.name or "_R2" in f.name for f in fastq_files) else "SINGLE"
+    return {
+        "accession": acc_dir.name,
+        "num_files": len(fastq_files),
+        "layout": layout,
+        "total_reads": stats.total_reads,
+        "total_bases": stats.total_bases,
+        "avg_read_length": stats.avg_read_length,
+        "min_read_length": stats.min_read_length,
+        "max_read_length": stats.max_read_length,
+        "n50": stats.n50,
+        "gc_content": stats.gc_content,
+        "avg_quality": (stats.quality_scores["mean"] if stats.quality_scores else None),
+    }
+
+
+def _print_statistics_summary(df: pd.DataFrame) -> None:
+    """Print the aggregate statistics and layout distribution for a report DataFrame."""
+    print("\nDataset Statistics Summary:")
+    print("==========================")
+    print(f"Total datasets: {len(df)}")
+    print(f"Total reads: {df['total_reads'].sum():,}")
+    print(f"Total bases: {df['total_bases'].sum():,}")
+    print(f"Average read length: {df['avg_read_length'].mean():.1f}")
+    print(f"Average GC content: {df['gc_content'].mean():.1f}%")
+
+    print("\nLayout distribution:")
+    for layout, count in df["layout"].value_counts().items():
+        print(f"  {layout}: {count}")
+
+
 def generate_statistics_report(fastq_folder: Union[str, Path], output_file: Union[str, Path]) -> None:
     """
     Generate comprehensive statistics report for downloaded datasets.
@@ -526,71 +572,18 @@ def generate_statistics_report(fastq_folder: Union[str, Path], output_file: Unio
 
     logger.info("Generating statistics report for downloaded datasets")
 
-    # Find all accession directories
     accession_dirs = [d for d in fastq_path.iterdir() if d.is_dir()]
-
     if not accession_dirs:
         logger.warning("No accession directories found")
         return
 
-    # Calculate statistics for each dataset
-    report_data = []
+    report_data = [row for acc_dir in accession_dirs if (row := _dataset_stats_row(acc_dir)) is not None]
 
-    for acc_dir in accession_dirs:
-        logger.info(f"Processing {acc_dir.name}")
-
-        # Find FASTQ files
-        fastq_files = list(acc_dir.glob("*.fastq*"))
-
-        if not fastq_files:
-            logger.warning(f"No FASTQ files found in {acc_dir}")
-            continue
-
-        try:
-            stats = calculate_read_statistics(fastq_files)
-
-            # Detect layout and technology from file patterns
-            layout = "PAIRED" if any("_2" in f.name or "_R2" in f.name for f in fastq_files) else "SINGLE"
-
-            report_data.append(
-                {
-                    "accession": acc_dir.name,
-                    "num_files": len(fastq_files),
-                    "layout": layout,
-                    "total_reads": stats.total_reads,
-                    "total_bases": stats.total_bases,
-                    "avg_read_length": stats.avg_read_length,
-                    "min_read_length": stats.min_read_length,
-                    "max_read_length": stats.max_read_length,
-                    "n50": stats.n50,
-                    "gc_content": stats.gc_content,
-                    "avg_quality": (stats.quality_scores["mean"] if stats.quality_scores else None),
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"Failed to calculate statistics for {acc_dir.name}: {e}")
-            continue
-
-    if report_data:
-        # Save report
-        df = pd.DataFrame(report_data)
-        df.to_csv(output_file, index=False)
-        logger.info(f"Statistics report saved to {output_file} ({len(report_data)} datasets)")
-
-        # Print summary
-        print("\nDataset Statistics Summary:")
-        print("==========================")
-        print(f"Total datasets: {len(report_data)}")
-        print(f"Total reads: {df['total_reads'].sum():,}")
-        print(f"Total bases: {df['total_bases'].sum():,}")
-        print(f"Average read length: {df['avg_read_length'].mean():.1f}")
-        print(f"Average GC content: {df['gc_content'].mean():.1f}%")
-
-        # Technology breakdown
-        layout_counts = df["layout"].value_counts()
-        print("\nLayout distribution:")
-        for layout, count in layout_counts.items():
-            print(f"  {layout}: {count}")
-    else:
+    if not report_data:
         logger.error("No statistics could be calculated")
+        return
+
+    df = pd.DataFrame(report_data)
+    df.to_csv(output_file, index=False)
+    logger.info(f"Statistics report saved to {output_file} ({len(report_data)} datasets)")
+    _print_statistics_summary(df)

--- a/metaquest/data/taxonomy.py
+++ b/metaquest/data/taxonomy.py
@@ -83,6 +83,35 @@ class NCBITaxonomyClient:
         # Get details for found IDs
         return self.get_taxonomy_details(tax_ids[:5])  # Limit to first 5 results
 
+    @staticmethod
+    def _element_text(parent, tag: str) -> str:
+        """Return the text of a child element, or '' when missing."""
+        el = parent.find(tag)
+        return (el.text or "") if el is not None else ""
+
+    @staticmethod
+    def _parse_lineage(taxon) -> str:
+        """Build a 'rank:name;...' lineage string from a <Taxon>'s LineageEx."""
+        lineage = []
+        lineage_elem = taxon.find(".//LineageEx")
+        if lineage_elem is not None:
+            for taxon_elem in lineage_elem.findall("Taxon"):
+                name = taxon_elem.find("ScientificName")
+                rank_elem = taxon_elem.find("Rank")
+                if name is not None and rank_elem is not None:
+                    lineage.append(f"{rank_elem.text}:{name.text}")
+        return ";".join(lineage)
+
+    @classmethod
+    def _parse_taxon_element(cls, taxon) -> Dict[str, str]:
+        """Parse a single <Taxon> element into a taxonomy detail dict."""
+        return {
+            "tax_id": cls._element_text(taxon, "TaxId"),
+            "scientific_name": cls._element_text(taxon, "ScientificName"),
+            "rank": cls._element_text(taxon, "Rank"),
+            "lineage": cls._parse_lineage(taxon),
+        }
+
     def get_taxonomy_details(self, tax_ids: List[str]) -> List[Dict[str, str]]:
         """
         Get detailed taxonomy information for given taxonomy IDs.
@@ -101,38 +130,8 @@ class NCBITaxonomyClient:
 
         response = self._make_request(fetch_url, params)
 
-        # Parse XML response
         root = ET.fromstring(response)
-        results = []
-
-        for taxon in root.findall("./Taxon"):
-            tid = taxon.find("TaxId")
-            tax_id = (tid.text or "") if tid is not None else ""
-            sname = taxon.find("ScientificName")
-            sci_name = (sname.text or "") if sname is not None else ""
-            rk = taxon.find("Rank")
-            rank = (rk.text or "") if rk is not None else ""
-
-            # Get lineage
-            lineage = []
-            lineage_elem = taxon.find(".//LineageEx")
-            if lineage_elem is not None:
-                for taxon_elem in lineage_elem.findall("Taxon"):
-                    name = taxon_elem.find("ScientificName")
-                    rank_elem = taxon_elem.find("Rank")
-                    if name is not None and rank_elem is not None:
-                        lineage.append(f"{rank_elem.text}:{name.text}")
-
-            results.append(
-                {
-                    "tax_id": tax_id,
-                    "scientific_name": sci_name,
-                    "rank": rank,
-                    "lineage": ";".join(lineage) if lineage else "",
-                }
-            )
-
-        return results
+        return [self._parse_taxon_element(taxon) for taxon in root.findall("./Taxon")]
 
     def validate_species_name(self, species_name: str) -> Dict[str, Union[str, bool]]:
         """
@@ -304,6 +303,33 @@ def validate_taxonomic_assignments(
         raise ProcessingError(f"Failed to validate taxonomic assignments: {e}")
 
 
+def _build_taxonomy_lineage_map(taxonomy_data: pd.DataFrame) -> Dict[str, Dict[str, str]]:
+    """Map original_name -> {rank: name} for valid taxonomy rows that carry a lineage."""
+    taxonomy_dict: Dict[str, Dict[str, str]] = {}
+    for _, row in taxonomy_data.iterrows():
+        if not (row["is_valid"] and row["lineage"]):
+            continue
+        lineage_dict = {}
+        for part in row["lineage"].split(";"):
+            if ":" in part:
+                rank, name = part.split(":", 1)
+                lineage_dict[rank.lower()] = name
+        taxonomy_dict[row["original_name"]] = lineage_dict
+    return taxonomy_dict
+
+
+def _summarize_sample_taxonomy(sample_abundances, taxonomy_dict, level, min_abundance) -> Dict[str, float]:
+    """Aggregate one sample's abundances by taxon at `level`, bucketing unknowns."""
+    sample_summary: Dict[str, float] = {}
+    for species, abundance in sample_abundances.items():
+        if abundance < min_abundance:
+            continue
+        lineage = taxonomy_dict.get(species, {})
+        taxon_name = lineage.get(level, f"Unclassified_{level}")
+        sample_summary[taxon_name] = sample_summary.get(taxon_name, 0) + abundance
+    return sample_summary
+
+
 def create_taxonomic_summary(
     abundance_data: pd.DataFrame,
     taxonomy_data: pd.DataFrame,
@@ -323,52 +349,14 @@ def create_taxonomic_summary(
         Sample x Taxon summary matrix
     """
     try:
-        # Parse taxonomic lineages
-        taxonomy_dict = {}
-        for _, row in taxonomy_data.iterrows():
-            if row["is_valid"] and row["lineage"]:
-                lineage_parts = row["lineage"].split(";")
-                lineage_dict = {}
+        taxonomy_dict = _build_taxonomy_lineage_map(taxonomy_data)
 
-                for part in lineage_parts:
-                    if ":" in part:
-                        rank, name = part.split(":", 1)
-                        lineage_dict[rank.lower()] = name
+        summary_data = [
+            _summarize_sample_taxonomy(abundance_data.loc[sample_name], taxonomy_dict, level, min_abundance)
+            for sample_name in abundance_data.index
+        ]
 
-                # Map by original_name (which should match abundance data columns)
-                taxonomy_dict[row["original_name"]] = lineage_dict
-
-        # Create summary matrix
-        summary_data = []
-
-        for sample_name in abundance_data.index:
-            sample_summary: dict = {}
-
-            for species, abundance in abundance_data.loc[sample_name].items():
-                if abundance < min_abundance:
-                    continue
-
-                # Get taxonomic assignment
-                if species in taxonomy_dict and level in taxonomy_dict[species]:
-                    taxon_name = taxonomy_dict[species][level]
-
-                    if taxon_name in sample_summary:
-                        sample_summary[taxon_name] += abundance
-                    else:
-                        sample_summary[taxon_name] = abundance
-                else:
-                    # Unclassified
-                    unclassified = f"Unclassified_{level}"
-                    if unclassified in sample_summary:
-                        sample_summary[unclassified] += abundance
-                    else:
-                        sample_summary[unclassified] = abundance
-
-            summary_data.append(sample_summary)
-
-        # Convert to DataFrame
-        summary_df = pd.DataFrame(summary_data, index=abundance_data.index)
-        summary_df = summary_df.fillna(0)
+        summary_df = pd.DataFrame(summary_data, index=abundance_data.index).fillna(0)
 
         logger.info(f"Created taxonomic summary at {level} level: {summary_df.shape}")
         return summary_df

--- a/metaquest/plugins/formats/branchwater.py
+++ b/metaquest/plugins/formats/branchwater.py
@@ -52,6 +52,34 @@ class BranchWaterFormatPlugin(Plugin):
         return all(col in headers for col in cls.REQUIRED_COLS)
 
     @classmethod
+    def _validate_headers(cls, file_path: Path, fieldnames: List[str]) -> None:
+        """Raise ValidationError if the required columns are missing."""
+        if not cls.validate_header(fieldnames):
+            missing = [col for col in cls.REQUIRED_COLS if col not in fieldnames]
+            raise ValidationError(f"Missing required columns in {file_path}: {', '.join(missing)}")
+
+    @classmethod
+    def _row_to_containment(cls, row: dict, genome_id: str, file_path: Path) -> Optional[Containment]:
+        """Convert one CSV row into a Containment, or None if the row is invalid."""
+        accession = row.get("acc", "")
+        if not validate_accession(accession):
+            logger.warning(f"Skipping row with invalid accession '{accession}' in {file_path}")
+            return None
+
+        containment_value = validate_containment_value(row.get("containment", ""))
+        if containment_value is None:
+            logger.warning(f"Skipping row with invalid containment value for {accession} in {file_path}")
+            return None
+
+        additional_data = {key: value for key, value in row.items() if key not in ("acc", "containment") and value}
+        return Containment(
+            accession=accession,
+            value=containment_value,
+            genome_id=genome_id,
+            additional_data=additional_data,
+        )
+
+    @classmethod
     def parse_file(cls, file_path: Union[str, Path], genome_id: str) -> List[Containment]:
         """
         Parse a Branchwater format file and return containment data.
@@ -72,39 +100,12 @@ class BranchWaterFormatPlugin(Plugin):
         try:
             with open(file_path, "r") as f:
                 reader = csv.DictReader(f)
-
-                # Validate headers
-                if not cls.validate_header(list(reader.fieldnames or [])):
-                    missing = [col for col in cls.REQUIRED_COLS if col not in (reader.fieldnames or [])]
-                    raise ValidationError(f"Missing required columns in {file_path}: {', '.join(missing)}")
+                cls._validate_headers(file_path, list(reader.fieldnames or []))
 
                 for row in reader:
-                    # Extract and validate accession
-                    accession = row.get("acc", "")
-                    if not validate_accession(accession):
-                        logger.warning(f"Skipping row with invalid accession '{accession}' in {file_path}")
-                        continue
-
-                    # Extract and validate containment value
-                    containment_value = validate_containment_value(row.get("containment", ""))
-                    if containment_value is None:
-                        logger.warning(f"Skipping row with invalid containment value for {accession} in {file_path}")
-                        continue
-
-                    # Create containment object with additional metadata
-                    additional_data = {}
-                    for key, value in row.items():
-                        if key not in ("acc", "containment") and value:
-                            additional_data[key] = value
-
-                    containment = Containment(
-                        accession=accession,
-                        value=containment_value,
-                        genome_id=genome_id,
-                        additional_data=additional_data,
-                    )
-
-                    containments.append(containment)
+                    containment = cls._row_to_containment(row, genome_id, file_path)
+                    if containment is not None:
+                        containments.append(containment)
 
             return containments
 

--- a/metaquest/sra/analytics.py
+++ b/metaquest/sra/analytics.py
@@ -400,6 +400,70 @@ class SRADatasetAnalyzer:
             recommendations=recommendations,
         )
 
+    def _collect_group_profiles(self, groups: Dict[str, List[str]]) -> Dict[str, QualityProfile]:
+        """Profile every accession across all groups, skipping and logging failures."""
+        all_profiles: Dict[str, QualityProfile] = {}
+        for accessions in groups.values():
+            for accession in accessions:
+                try:
+                    all_profiles[accession] = self.profile_dataset_quality(accession)
+                except Exception as e:
+                    logger.warning(f"Failed to profile {accession}: {e}")
+        return all_profiles
+
+    @staticmethod
+    def _group_of(accession: str, groups: Dict[str, List[str]]) -> Optional[str]:
+        """Return the first group name containing the accession, or None."""
+        for group_name, acc_list in groups.items():
+            if accession in acc_list:
+                return group_name
+        return None
+
+    @classmethod
+    def _build_comparison_dataframe(cls, all_profiles, groups) -> pd.DataFrame:
+        """Assemble a per-accession comparison DataFrame tagged with each group."""
+        rows = []
+        for accession, profile in all_profiles.items():
+            group = cls._group_of(accession, groups)
+            if not group:
+                continue
+            rows.append(
+                {
+                    "accession": accession,
+                    "group": group,
+                    "avg_read_length": profile.avg_read_length,
+                    "gc_content": profile.gc_content,
+                    "total_reads": profile.total_reads,
+                    "complexity_score": profile.complexity_score,
+                    "quality_grade": profile.quality_grade,
+                    "adapter_contamination": profile.contamination_indicators.get("adapter_contamination", 0),
+                }
+            )
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    def _group_summary_statistics(comparison_df, groups, numeric_cols) -> Dict[str, Dict[str, Any]]:
+        """Compute mean/std/median/min/max per numeric column for each non-empty group."""
+        summary_stats: dict = {}
+        for group in groups.keys():
+            group_data = comparison_df[comparison_df["group"] == group]
+            if group_data.empty:
+                continue
+            summary_stats[group] = {}
+            for col in numeric_cols:
+                if col not in group_data.columns:
+                    continue
+                values = group_data[col].dropna()
+                if not values.empty:
+                    summary_stats[group][col] = {
+                        "mean": float(values.mean()),
+                        "std": float(values.std()),
+                        "median": float(values.median()),
+                        "min": float(values.min()),
+                        "max": float(values.max()),
+                    }
+        return summary_stats
+
     def compare_datasets(
         self, groups: Dict[str, List[str]], metadata_df: Optional[pd.DataFrame] = None
     ) -> ComparativeAnalysis:
@@ -415,41 +479,8 @@ class SRADatasetAnalyzer:
         """
         logger.info(f"Comparing {len(groups)} dataset groups")
 
-        # Collect quality profiles for all datasets
-        all_profiles = {}
-        for group_name, accessions in groups.items():
-            for accession in accessions:
-                try:
-                    profile = self.profile_dataset_quality(accession)
-                    all_profiles[accession] = profile
-                except Exception as e:
-                    logger.warning(f"Failed to profile {accession}: {e}")
-
-        # Create comparison DataFrame
-        comparison_data = []
-        for accession, profile in all_profiles.items():
-            # Find which group this accession belongs to
-            group = None
-            for group_name, acc_list in groups.items():
-                if accession in acc_list:
-                    group = group_name
-                    break
-
-            if group:
-                comparison_data.append(
-                    {
-                        "accession": accession,
-                        "group": group,
-                        "avg_read_length": profile.avg_read_length,
-                        "gc_content": profile.gc_content,
-                        "total_reads": profile.total_reads,
-                        "complexity_score": profile.complexity_score,
-                        "quality_grade": profile.quality_grade,
-                        "adapter_contamination": profile.contamination_indicators.get("adapter_contamination", 0),
-                    }
-                )
-
-        comparison_df = pd.DataFrame(comparison_data)
+        all_profiles = self._collect_group_profiles(groups)
+        comparison_df = self._build_comparison_dataframe(all_profiles, groups)
 
         if comparison_df.empty:
             logger.warning("No data available for comparison")
@@ -464,33 +495,10 @@ class SRADatasetAnalyzer:
                 visualization_data={},
             )
 
-        # Calculate summary statistics
-        summary_stats: dict = {}
         numeric_cols = ["avg_read_length", "gc_content", "total_reads", "complexity_score"]
-
-        for group in groups.keys():
-            group_data = comparison_df[comparison_df["group"] == group]
-            if not group_data.empty:
-                summary_stats[group] = {}
-                for col in numeric_cols:
-                    if col in group_data.columns:
-                        values = group_data[col].dropna()
-                        if not values.empty:
-                            summary_stats[group][col] = {
-                                "mean": float(values.mean()),
-                                "std": float(values.std()),
-                                "median": float(values.median()),
-                                "min": float(values.min()),
-                                "max": float(values.max()),
-                            }
-
-        # Perform statistical tests
+        summary_stats = self._group_summary_statistics(comparison_df, groups, numeric_cols)
         statistical_tests = self._perform_statistical_tests(comparison_df, groups)
-
-        # Detect outliers
         outliers = self._detect_outliers(comparison_df)
-
-        # Generate recommendations
         recommendations = self._generate_comparative_recommendations(summary_stats, statistical_tests, outliers)
 
         return ComparativeAnalysis(


### PR DESCRIPTION
## Summary

Continues the complexity-reduction effort (after #31) by decomposing every function still at cyclomatic-complexity rank C(14). Each change is a behavior-preserving helper extraction verified by the existing tests.

| Function | Before | After |
|---|---|---|
| `data/taxonomy.py::NCBITaxonomyClient.get_taxonomy_details` | C (14) | **A (3)** |
| `data/taxonomy.py::create_taxonomic_summary` | C (14) | **A (3)** |
| `plugins/formats/branchwater.py::BranchWaterFormatPlugin.parse_file` | C (14) | **B (6)** |
| `sra/analytics.py::SRADatasetAnalyzer.compare_datasets` | C (14) | **A (2)** |
| `data/sra_metadata.py::generate_statistics_report` | C (14) | **B (8)** |

## What changed

- **get_taxonomy_details**: `_element_text`, `_parse_lineage`, `_parse_taxon_element`; the method is now a comprehension over parsed `<Taxon>` elements.
- **create_taxonomic_summary**: `_build_taxonomy_lineage_map` and `_summarize_sample_taxonomy` (the per-taxon accumulation simplified to `dict.get(...) + abundance`).
- **parse_file**: `_validate_headers` and `_row_to_containment` (per-row validation returning `None` for skipped rows).
- **compare_datasets**: `_collect_group_profiles`, `_group_of`, `_build_comparison_dataframe`, `_group_summary_statistics`.
- **generate_statistics_report**: `_dataset_stats_row` and `_print_statistics_summary`.

## Verification

- Full suite: **1190 passed**
- `make check` green (Black, flake8, mypy, the CDN guard, and the radon complexity ceiling)
- No function at rank C(14) or worse remains (worst is now C-13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)