### PR TITLE
Open generated HTML reliably in the browser on macOS

### DIFF
--- a/metaquest/cli/commands/explore.py
+++ b/metaquest/cli/commands/explore.py
@@ -117,6 +117,12 @@ class ExploreContainmentCommand(BaseCommand):
             default="taxonomy_cache.tsv",
             help="Taxonomy cache file for GTDB lookups",
         )
+        parser.add_argument(
+            "--open",
+            dest="open_browser",
+            action="store_true",
+            help="Open the generated explorer in a browser",
+        )
 
     def execute(self, args: argparse.Namespace) -> int:
         try:
@@ -158,6 +164,13 @@ class ExploreContainmentCommand(BaseCommand):
                 min_containment=args.min_containment,
             )
             self.logger.info("Generated containment explorer: %s", output_path)
+
+            if getattr(args, "open_browser", False):
+                from metaquest.utils.browser import open_in_browser
+
+                if not open_in_browser(output_path):
+                    self.logger.warning("Could not open a browser automatically for %s", output_path)
+
             return 0
         except MetaQuestError as e:
             self.logger.error("Error generating explorer: %s", e)

--- a/metaquest/cli/commands/sra_intelligent.py
+++ b/metaquest/cli/commands/sra_intelligent.py
@@ -19,6 +19,7 @@ from metaquest.sra import (
     DownloadSession,
     QualityProfile,
 )
+from metaquest.utils.browser import open_in_browser
 
 logger = logging.getLogger(__name__)
 
@@ -480,6 +481,11 @@ class SRAInteractiveDashboardCommand(BaseCommand):
             default="full",
             help="Type of dashboard to generate",
         )
+        parser.add_argument(
+            "--no-open",
+            action="store_true",
+            help="Do not open the generated dashboard in a browser",
+        )
 
     def _read_accessions(self, filename: str) -> List[str]:
         """Read accessions from file."""
@@ -534,16 +540,13 @@ class SRAInteractiveDashboardCommand(BaseCommand):
 
             if dashboard_path:
                 print("\n✅ Dashboard generated successfully!")
-                print(f"Open in browser: {dashboard_path}")
+                print(f"Open in browser: {dashboard_path.resolve().as_uri()}")
 
-                # Try to open in browser
-                try:
-                    import webbrowser
-
-                    webbrowser.open(f"file://{dashboard_path.absolute()}")
-                    print("Dashboard opened in browser")
-                except Exception:
-                    pass
+                if not args.no_open:
+                    if open_in_browser(dashboard_path):
+                        print("Dashboard opened in browser")
+                    else:
+                        print("Could not open a browser automatically; open the link above manually.")
 
                 return 0
             else:

--- a/metaquest/utils/browser.py
+++ b/metaquest/utils/browser.py
@@ -1,0 +1,47 @@
+"""Helpers for opening generated HTML output in a web browser.
+
+Used by the commands that produce interactive HTML (dashboards, the
+containment explorer) so a developer can view the result immediately.
+"""
+
+import logging
+import platform
+import subprocess
+import webbrowser
+from pathlib import Path
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+
+def open_in_browser(path: Union[str, Path]) -> bool:
+    """Open a local HTML file in the default browser.
+
+    The path is turned into a percent-encoded ``file://`` URI so locations
+    containing spaces work. On macOS the ``open`` command is used directly:
+    Python's ``webbrowser`` backend there (``MacOSXOSAScript``) can report
+    success without actually opening anything. Other platforms use the
+    ``webbrowser`` module.
+
+    Args:
+        path: Path to the HTML file to open.
+
+    Returns:
+        True if a browser was launched, False otherwise.
+    """
+    resolved = Path(path).resolve()
+    uri = resolved.as_uri()
+
+    if platform.system() == "Darwin":
+        try:
+            subprocess.run(["open", str(resolved)], check=True)
+            return True
+        except Exception as e:
+            logger.warning("Could not open browser with `open`: %s", e)
+            return False
+
+    try:
+        return webbrowser.open(uri)
+    except Exception as e:
+        logger.warning("Could not open browser: %s", e)
+        return False

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,57 @@
+"""Tests for the browser-opening helper in metaquest.utils.browser."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from metaquest.utils import browser
+
+
+class TestOpenInBrowser:
+    """Tests for open_in_browser across platforms."""
+
+    def test_macos_uses_open_command(self, tmp_path):
+        """On macOS the `open` command is invoked with the resolved path."""
+        html = tmp_path / "dashboard.html"
+        html.write_text("<html></html>")
+
+        with patch.object(browser.platform, "system", return_value="Darwin"):
+            with patch.object(browser.subprocess, "run") as mock_run:
+                result = browser.open_in_browser(html)
+
+        assert result is True
+        args, _ = mock_run.call_args
+        assert args[0] == ["open", str(html.resolve())]
+
+    def test_macos_returns_false_when_open_fails(self, tmp_path):
+        """A failing `open` command yields False rather than raising."""
+        html = tmp_path / "dashboard.html"
+        html.write_text("<html></html>")
+
+        with patch.object(browser.platform, "system", return_value="Darwin"):
+            with patch.object(browser.subprocess, "run", side_effect=OSError("boom")):
+                assert browser.open_in_browser(html) is False
+
+    def test_non_macos_uses_webbrowser_with_encoded_uri(self, tmp_path):
+        """Other platforms hand webbrowser a percent-encoded file URI."""
+        # A space in the path must be encoded so the browser can open it.
+        html = tmp_path / "my report.html"
+        html.write_text("<html></html>")
+
+        with patch.object(browser.platform, "system", return_value="Linux"):
+            with patch.object(browser.webbrowser, "open", return_value=True) as mock_open:
+                result = browser.open_in_browser(html)
+
+        assert result is True
+        (uri,) = mock_open.call_args[0]
+        assert uri.startswith("file://")
+        assert "my%20report.html" in uri
+        assert uri == Path(html).resolve().as_uri()
+
+    def test_non_macos_returns_false_on_webbrowser_error(self, tmp_path):
+        """A webbrowser failure yields False rather than raising."""
+        html = tmp_path / "dashboard.html"
+        html.write_text("<html></html>")
+
+        with patch.object(browser.platform, "system", return_value="Linux"):
+            with patch.object(browser.webbrowser, "open", side_effect=RuntimeError("no display")):
+                assert browser.open_in_browser(html) is False

--- a/tests/test_cli_sra_intelligent.py
+++ b/tests/test_cli_sra_intelligent.py
@@ -534,6 +534,7 @@ class TestSRAInteractiveDashboardCommand:
             output_dir=str(tmp_path / "dashboards"),
             title="Test Dashboard",
             dashboard_type="quality",
+            no_open=True,
         )
 
         mock_dashboard_path = tmp_path / "dashboards" / "dashboard.html"
@@ -546,6 +547,36 @@ class TestSRAInteractiveDashboardCommand:
             result = cmd.execute(args)
 
         assert result == 0
+
+    def test_execute_opens_dashboard_when_not_suppressed(self, tmp_path):
+        """Without --no-open the generated dashboard is passed to open_in_browser."""
+        cmd = SRAInteractiveDashboardCommand()
+
+        accessions_file = tmp_path / "accessions.txt"
+        accessions_file.write_text("SRR001\n")
+
+        args = Namespace(
+            accessions_file=str(accessions_file),
+            download_session=None,
+            quality_profiles=None,
+            output_dir=str(tmp_path / "dashboards"),
+            title="Test Dashboard",
+            dashboard_type="quality",
+            no_open=False,
+        )
+
+        mock_dashboard_path = tmp_path / "dashboards" / "dashboard.html"
+
+        with patch("metaquest.cli.commands.sra_intelligent.SRAReportGenerator") as mock_reporter_class:
+            with patch("metaquest.cli.commands.sra_intelligent.open_in_browser", return_value=True) as mock_open:
+                mock_reporter = Mock()
+                mock_reporter.generate_quality_dashboard.return_value = mock_dashboard_path
+                mock_reporter_class.return_value = mock_reporter
+
+                result = cmd.execute(args)
+
+        assert result == 0
+        mock_open.assert_called_once_with(mock_dashboard_path)
 
     def test_execute_full_dashboard(self, tmp_path):
         """Test full dashboard generation."""
@@ -561,6 +592,7 @@ class TestSRAInteractiveDashboardCommand:
             output_dir=str(tmp_path / "dashboards"),
             title="Full Dashboard",
             dashboard_type="full",
+            no_open=True,
         )
 
         mock_dashboard_path = tmp_path / "dashboards" / "dashboard.html"


### PR DESCRIPTION
## Summary

Make the generated interactive HTML (dashboards, the containment explorer) reliably open in the browser while developing on macOS.

The `sra-dashboard` command built an unencoded `file://<path>` URL and opened it with Python's `webbrowser` module. On macOS that backend (`MacOSXOSAScript`) can report success without actually opening anything, an unencoded URL breaks whenever the output path contains a space, and the code swallowed failures silently — so nothing appeared and there was no feedback.

## What changed

- **New `metaquest/utils/browser.open_in_browser`**: builds a percent-encoded `file://` URI via `Path.as_uri()`, and on macOS shells out to `open` (reliable via LaunchServices) rather than the `webbrowser` module. Returns a `bool` so callers can report failure instead of guessing.
- **`sra-dashboard`**: uses the helper, prints the clickable file URI, and gains a `--no-open` flag to suppress auto-opening (e.g. on a headless box).
- **`explore_containment`**: gains an `--open` flag to view the generated explorer immediately.

## Verification

- New tests cover the macOS `open` path, the non-macOS `webbrowser` path (asserting the URI is percent-encoded), both failure paths, and the dashboard command invoking the opener when not suppressed.
- Verified end-to-end on macOS: `open_in_browser` on a path containing a space returned `True` and opened the file.
- Full suite: **1195 passed**; `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)