### PR TITLE
Embed plotly.js inline so report charts render offline

### DIFF
--- a/metaquest/sra/reporting.py
+++ b/metaquest/sra/reporting.py
@@ -40,7 +40,7 @@ from metaquest.sra.analytics import (
     ComparativeAnalysis,
     SRADatasetAnalyzer,
 )
-from metaquest.utils.html import plotly_cdn_script
+from metaquest.utils.html import plotly_js_script
 
 logger = logging.getLogger(__name__)
 
@@ -452,7 +452,7 @@ class SRAReportGenerator:
 <html>
 <head>
     <title>SRA Download Summary - {{ session.session_id }}</title>
-    {{ plotly_cdn|safe }}
+    {{ plotly_js|safe }}
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         .header { background-color: #3498db; color: white;
@@ -536,7 +536,7 @@ class SRAReportGenerator:
         """
 
         template = Environment(loader=BaseLoader(), autoescape=True).from_string(template_str)
-        return template.render(plotly_cdn=plotly_cdn_script(), **report_data)
+        return template.render(plotly_js=plotly_js_script(), **report_data)
 
     def _generate_quality_html(self, dashboard_data: Dict[str, Any]) -> str:
         """Generate HTML content for quality dashboard."""
@@ -548,7 +548,7 @@ class SRAReportGenerator:
 <html>
 <head>
     <title>{{ title }}</title>
-    {{ plotly_cdn|safe }}
+    {{ plotly_js|safe }}
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         .header { background-color: #2ecc71; color: white;
@@ -628,7 +628,7 @@ class SRAReportGenerator:
         """
 
         template = Environment(loader=BaseLoader(), autoescape=True).from_string(template_str)
-        return template.render(plotly_cdn=plotly_cdn_script(), **dashboard_data)
+        return template.render(plotly_js=plotly_js_script(), **dashboard_data)
 
     def _generate_comparative_html(self, report_data: Dict[str, Any]) -> str:
         """Generate HTML content for comparative analysis report."""
@@ -640,7 +640,7 @@ class SRAReportGenerator:
 <html>
 <head>
     <title>{{ title }}</title>
-    {{ plotly_cdn|safe }}
+    {{ plotly_js|safe }}
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         .header { background-color: #9b59b6; color: white;
@@ -708,7 +708,7 @@ class SRAReportGenerator:
         """
 
         template = Environment(loader=BaseLoader(), autoescape=True).from_string(template_str)
-        return template.render(plotly_cdn=plotly_cdn_script(), **report_data)
+        return template.render(plotly_js=plotly_js_script(), **report_data)
 
     def _generate_simple_download_html(self, report_data: Dict[str, Any]) -> str:
         """Generate simple HTML without Jinja2."""

--- a/metaquest/utils/html.py
+++ b/metaquest/utils/html.py
@@ -1,29 +1,26 @@
 """Shared HTML assets for MetaQuest report and dashboard generators.
 
-Centralizes the Plotly CDN ``<script>`` tag and the sortable/filterable table
+Centralizes the inline Plotly ``<script>`` tag and the sortable/filterable table
 JavaScript so the several HTML generators do not each carry their own copy.
 """
 
-# Fallback plotly.js version used only if the installed plotly cannot report
-# its bundled version. Kept close to a recent release.
-_FALLBACK_PLOTLYJS_VERSION = "3.0.1"
 
+def plotly_js_script() -> str:
+    """Return a ``<script>`` tag with plotly.js embedded inline.
 
-def plotly_cdn_script() -> str:
-    """Return a ``<script>`` tag loading the plotly.js the report expects.
-
-    The version is taken from the installed plotly.py so the CDN runtime
-    matches the figures it renders. This avoids the old
-    ``plotly-latest.min.js`` alias, which is frozen at plotly.js v1 and cannot
-    render output produced by modern plotly.py.
+    Uses the plotly.js bundled with the installed plotly.py, so the runtime
+    always matches the figures it renders and the report renders with no
+    network access (the individual figures are emitted with
+    ``include_plotlyjs=False`` and share this single embedded copy). Returns an
+    empty string if plotly is unavailable, in which case no figures are
+    generated either.
     """
     try:
-        from plotly.offline import get_plotlyjs_version
+        from plotly.offline import get_plotlyjs
 
-        version = get_plotlyjs_version()
+        return f'<script type="text/javascript">{get_plotlyjs()}</script>'
     except Exception:
-        version = _FALLBACK_PLOTLYJS_VERSION
-    return f'<script src="https://cdn.plot.ly/plotly-{version}.min.js"></script>'
+        return ""
 
 
 # Client-side helpers for the interactive results table: full-text filtering,

--- a/metaquest/visualization/explorer.py
+++ b/metaquest/visualization/explorer.py
@@ -16,7 +16,7 @@ import pandas as pd
 
 from metaquest.core.models import TaxonomyInfo
 from metaquest.core.utils import get_genome_columns
-from metaquest.utils.html import plotly_cdn_script, TABLE_SCRIPT
+from metaquest.utils.html import plotly_js_script, TABLE_SCRIPT
 
 try:
     import plotly.express as px
@@ -236,7 +236,7 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <title>{{ title }}</title>
-    {{ plotly_cdn|safe }}
+    {{ plotly_js|safe }}
     <style>
         * { box-sizing: border-box; }
         body {
@@ -418,7 +418,7 @@ def _assemble_html(title, summary, sunburst_html, heatmap_html, table_rows, box_
             table_rows=table_rows,
             box_html=box_html,
             bar_html=bar_html,
-            plotly_cdn=plotly_cdn_script(),
+            plotly_js=plotly_js_script(),
             table_script=TABLE_SCRIPT,
         )
     return _assemble_html_simple(title, summary, table_rows, sunburst_html, heatmap_html, box_html, bar_html)
@@ -455,7 +455,7 @@ def _assemble_html_simple(title, summary, table_rows, sunburst_html, heatmap_htm
 
     return f"""<!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><title>{safe_title}</title>
-{plotly_cdn_script()}
+{plotly_js_script()}
 <style>
 body {{ font-family: Arial, sans-serif; margin: 0; padding: 0; background: #fafafa; }}
 .header {{ background: #2c3e50; color: #ecf0f1; padding: 24px 32px; }}

--- a/tests/test_html_assets.py
+++ b/tests/test_html_assets.py
@@ -5,25 +5,26 @@ from unittest.mock import patch
 from metaquest.utils import html
 
 
-class TestPlotlyCdnScript:
-    """Tests for the pinned Plotly CDN script tag."""
+class TestPlotlyJsScript:
+    """Tests for the inline Plotly script tag."""
 
-    def test_uses_installed_plotlyjs_version(self):
-        """The tag pins the version reported by the installed plotly."""
-        with patch("plotly.offline.get_plotlyjs_version", return_value="9.9.9"):
-            tag = html.plotly_cdn_script()
-        assert tag == '<script src="https://cdn.plot.ly/plotly-9.9.9.min.js"></script>'
+    def test_embeds_plotlyjs_inline(self):
+        """The tag embeds the bundled plotly.js inline, not a network URL."""
+        with patch("plotly.offline.get_plotlyjs", return_value="PLOTLY_JS_BODY"):
+            tag = html.plotly_js_script()
+        assert tag == '<script type="text/javascript">PLOTLY_JS_BODY</script>'
 
-    def test_never_emits_the_frozen_latest_alias(self):
-        """The frozen 'plotly-latest' alias must never be produced."""
-        assert "plotly-latest" not in html.plotly_cdn_script()
+    def test_never_references_a_remote_cdn(self):
+        """The opening <script> tag must be inline, never loading from a remote host."""
+        tag = html.plotly_js_script()
+        opening = tag[: tag.index(">") + 1]
+        assert "src=" not in opening
+        assert "cdn.plot.ly" not in opening
 
-    def test_falls_back_when_version_lookup_fails(self):
-        """A lookup failure yields the conservative fallback version, not a crash."""
-        with patch("plotly.offline.get_plotlyjs_version", side_effect=RuntimeError("boom")):
-            tag = html.plotly_cdn_script()
-        assert html._FALLBACK_PLOTLYJS_VERSION in tag
-        assert tag.startswith("<script") and tag.endswith("</script>")
+    def test_returns_empty_when_plotly_unavailable(self):
+        """A failure to obtain plotly.js yields an empty string, not a crash."""
+        with patch("plotly.offline.get_plotlyjs", side_effect=RuntimeError("boom")):
+            assert html.plotly_js_script() == ""
 
 
 class TestTableScript:


### PR DESCRIPTION
## Summary

Follow-up to #33: make the interactive charts in the dashboards and containment explorer render **without network access**.

Previously the HTML loaded plotly.js from `cdn.plot.ly`, so while the page opened fine offline, the charts stayed blank. Now the plotly.js bundled with the installed plotly.py is embedded directly in each document.

## What changed

- **`utils/html`**: `plotly_cdn_script()` → `plotly_js_script()`, which returns a `<script>` tag containing `get_plotlyjs()` inline. The individual figures already render with `include_plotlyjs=False`, so they share this single embedded copy. Because the embedded JS comes from the same installed plotly.py that generates the figures, there is no runtime/figure version drift.
- Updated the five call sites in `explorer.py` and `sra/reporting.py` (the `<head>` script tag plus the Jinja/f-string render variables, now `plotly_js`).
- Updated the asset tests for the inline behavior.

## Trade-off

Each report grows by ~4.6 MB (one embedded copy of plotly.js). That's the cost of a self-contained, offline-renderable file — which is also more robust for archiving and sharing (no external dependency, no CDN version drift).

## Verification

- Generated an explorer end-to-end: it embeds plotly.js and loads nothing over the network (no remote `<script src="http…">`).
- Full suite: **1195 passed**; `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)