### PR TITLE
Local inventory: status command + genome download skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,25 @@ To analyze a single sample from the summary, you can use the `single_sample` com
 metaquest single_sample --summary-file parsed_containment.txt --metadata-file parsed_metadata.txt --summary-column GCF_000008985.1 --metadata-column Sample_Scientific_Name --threshold 0.95
 ```
 
+### 10. Checking What Is Already Available Locally
+
+Before downloading, use `status` to see which reads, metadata, and genomes are already present
+so nothing is fetched twice. Given a wanted list it also reports what is still missing:
+
+```bash
+metaquest status --accessions-file accessions.txt --list-missing
+metaquest status --parsed-containment parsed_containment.txt --json
+```
+
+The command reconciles against the standard layout (`fastq/<ACC>/`, `metadata/<ACC>_metadata.xml`,
+`genomes/<GCF>.fna`); override the locations with `--fastq-folder`, `--metadata-folder`, and
+`--genomes-folder`. Genome downloads skip accessions whose FASTA already exists; pass `--force` to
+re-download or `--dry-run` to report present-vs-missing without downloading:
+
+```bash
+metaquest genome_download --accessions GCF_000006945.2 --dry-run
+```
+
 ## Advanced SRA Operations
 
 ### Which SRA download command should I use?

--- a/metaquest/cli/commands/__init__.py
+++ b/metaquest/cli/commands/__init__.py
@@ -15,6 +15,7 @@ from .metadata import (
 )
 from .samples import SingleSampleCommand
 from .sra import DownloadSraCommand, AssembleDatasetsCommand
+from .status import StatusCommand
 from .test_data import DownloadTestGenomeCommand
 from .genome import GenomeSearchCommand, GenomeDownloadCommand, GenomePrepareCommand
 from .explore import (
@@ -36,6 +37,7 @@ __all__ = [
     "SingleSampleCommand",
     "DownloadSraCommand",
     "AssembleDatasetsCommand",
+    "StatusCommand",
     "DownloadTestGenomeCommand",
     "GenomeSearchCommand",
     "GenomeDownloadCommand",

--- a/metaquest/cli/commands/genome.py
+++ b/metaquest/cli/commands/genome.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from metaquest.cli.base import BaseCommand
 from metaquest.core.exceptions import MetaQuestError
-from metaquest.data.genome_download import download_genomes, extract_and_organize
+from metaquest.data.genome_download import download_genomes, extract_and_organize, partition_present_genomes
 from metaquest.data.gtdb import (
     get_accessions_for_genus,
     get_accessions_for_species,
@@ -136,6 +136,16 @@ class GenomeDownloadCommand(BaseCommand):
             default=None,
             help="Filter by assembly level",
         )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-download genomes even if their FASTA already exists",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report which genomes are already present vs would be downloaded, without downloading",
+        )
 
     def _collect_accessions(self, args: argparse.Namespace) -> list:
         """Collect accessions from all input sources."""
@@ -177,10 +187,21 @@ class GenomeDownloadCommand(BaseCommand):
             output_dir = Path(args.output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
 
-            self.logger.info("Downloading %d genome(s) to %s", len(accessions), output_dir)
+            present, missing = partition_present_genomes(accessions, output_dir)
+            to_download = accessions if args.force else missing
 
+            if present and not args.force:
+                self.logger.info("%d genome(s) already present, skipping", len(present))
+            if args.dry_run:
+                self.logger.info("Dry run: %d already present, %d would be downloaded", len(present), len(to_download))
+                return 0
+            if not to_download:
+                self.logger.info("All %d genome(s) already present", len(accessions))
+                return 0
+
+            self.logger.info("Downloading %d genome(s) to %s", len(to_download), output_dir)
             zip_path = download_genomes(
-                accessions,
+                to_download,
                 output_dir,
                 assembly_level=args.assembly_level,
             )

--- a/metaquest/cli/commands/status.py
+++ b/metaquest/cli/commands/status.py
@@ -1,0 +1,132 @@
+"""Local inventory / status CLI command.
+
+Reports what MetaQuest has already downloaded locally (SRA reads, NCBI metadata,
+genome assemblies) so a user can see what is available without re-downloading,
+and optionally reconciles that against a wanted list of accessions.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+from metaquest.cli.base import BaseCommand
+from metaquest.core.exceptions import MetaQuestError
+from metaquest.data.sra import accession_has_fastq
+
+
+class StatusCommand(BaseCommand):
+    """Command to report locally available data and reconcile it against a wanted list."""
+
+    @property
+    def name(self) -> str:
+        return "status"
+
+    @property
+    def help(self) -> str:
+        return "Report which SRA reads, metadata, and genomes are already available locally"
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--fastq-folder", default="fastq", help="Folder holding per-accession FASTQ downloads")
+        parser.add_argument("--metadata-folder", default="metadata", help="Folder holding NCBI metadata XML")
+        parser.add_argument("--genomes-folder", default="genomes", help="Folder holding genome FASTA files")
+        parser.add_argument(
+            "--accessions-file",
+            help="Optional file of SRA accessions (one per line) to reconcile against local FASTQ/metadata",
+        )
+        parser.add_argument(
+            "--parsed-containment",
+            help="Optional parsed containment table; its sample accessions are the wanted list",
+        )
+        parser.add_argument("--list-missing", action="store_true", help="Also print the accessions that are missing")
+        parser.add_argument("--json", action="store_true", help="Emit the report as JSON")
+
+    def _wanted_accessions(self, args: argparse.Namespace) -> List[str]:
+        """Load the wanted accession list from a file and/or a parsed containment table."""
+        wanted: List[str] = []
+        if args.accessions_file:
+            path = Path(args.accessions_file)
+            if not path.exists():
+                raise MetaQuestError(f"Accessions file not found: {path}")
+            wanted += [ln.strip() for ln in path.read_text().splitlines() if ln.strip() and not ln.startswith("#")]
+        if args.parsed_containment:
+            import pandas as pd
+
+            path = Path(args.parsed_containment)
+            if not path.exists():
+                raise MetaQuestError(f"Parsed containment file not found: {path}")
+            wanted += [str(i) for i in pd.read_csv(path, sep="\t", index_col=0).index]
+        # de-duplicate, preserve order
+        return list(dict.fromkeys(wanted))
+
+    @staticmethod
+    def _reconcile(wanted: List[str], present_fn) -> Tuple[List[str], List[str]]:
+        """Split a wanted list into (present, missing) using a predicate."""
+        present = [a for a in wanted if present_fn(a)]
+        missing = [a for a in wanted if a not in present]
+        return present, missing
+
+    def _build_report(self, args: argparse.Namespace) -> dict:
+        fastq_dir = Path(args.fastq_folder)
+        meta_dir = Path(args.metadata_folder)
+        genomes_dir = Path(args.genomes_folder)
+
+        if fastq_dir.is_dir():
+            on_disk_fastq = sorted(d.name for d in fastq_dir.iterdir() if accession_has_fastq(d))
+        else:
+            on_disk_fastq = []
+        on_disk_meta = sorted(p.name[: -len("_metadata.xml")] for p in meta_dir.glob("*_metadata.xml"))
+        genome_globs = ("*.fna", "*.fna.gz", "*.fasta", "*.fasta.gz", "*.fa", "*.fa.gz")
+        on_disk_genomes = sorted({p.name for g in genome_globs for p in genomes_dir.glob(g)})
+
+        report: dict = {
+            "on_disk": {
+                "fastq_accessions": len(on_disk_fastq),
+                "metadata_xml": len(on_disk_meta),
+                "genome_fasta": len(on_disk_genomes),
+            }
+        }
+
+        wanted = self._wanted_accessions(args)
+        if wanted:
+            fastq_present, fastq_missing = self._reconcile(wanted, lambda a: accession_has_fastq(fastq_dir / a))
+            meta_present, meta_missing = self._reconcile(wanted, lambda a: (meta_dir / f"{a}_metadata.xml").exists())
+            report["wanted"] = {
+                "total": len(wanted),
+                "fastq_present": len(fastq_present),
+                "fastq_missing": fastq_missing,
+                "metadata_present": len(meta_present),
+                "metadata_missing": meta_missing,
+            }
+        return report
+
+    def _print_report(self, report: dict, list_missing: bool) -> None:
+        od = report["on_disk"]
+        print("Local inventory")
+        print("===============")
+        print(f"  FASTQ accessions on disk : {od['fastq_accessions']}")
+        print(f"  Metadata XML on disk     : {od['metadata_xml']}")
+        print(f"  Genome FASTA on disk     : {od['genome_fasta']}")
+
+        w = report.get("wanted")
+        if w:
+            print(f"\nReconciled against {w['total']} wanted accession(s)")
+            print(f"  FASTQ    : {w['fastq_present']} present, {len(w['fastq_missing'])} missing")
+            print(f"  Metadata : {w['metadata_present']} present, {len(w['metadata_missing'])} missing")
+            if list_missing:
+                if w["fastq_missing"]:
+                    print("  Missing FASTQ    : " + ", ".join(w["fastq_missing"]))
+                if w["metadata_missing"]:
+                    print("  Missing metadata : " + ", ".join(w["metadata_missing"]))
+
+    def execute(self, args: argparse.Namespace) -> int:
+        try:
+            report = self._build_report(args)
+            if args.json:
+                print(json.dumps(report, indent=2))
+            else:
+                self._print_report(report, args.list_missing)
+            return 0
+        except MetaQuestError as e:
+            self.logger.error(f"Error building status report: {e}")
+            return 1

--- a/metaquest/cli/main.py
+++ b/metaquest/cli/main.py
@@ -29,6 +29,7 @@ from metaquest.cli.commands import (
     SingleSampleCommand,
     DownloadSraCommand,
     AssembleDatasetsCommand,
+    StatusCommand,
     DownloadTestGenomeCommand,
     GenomeSearchCommand,
     GenomeDownloadCommand,
@@ -73,6 +74,7 @@ def register_all_commands() -> None:
         PlotMetadataCountsCommand(),
         DownloadSraCommand(),
         AssembleDatasetsCommand(),
+        StatusCommand(),
         # Enhanced SRA commands
         SRAInfoCommand(),
         SRADownloadEnhancedCommand(),

--- a/metaquest/data/genome_download.py
+++ b/metaquest/data/genome_download.py
@@ -11,7 +11,7 @@ import re
 import shutil
 import zipfile
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from metaquest.core.constants import GENOME_ACCESSION_PATTERN, GENOME_ACCESSION_PREFIXES
 from metaquest.core.exceptions import DataAccessError
@@ -39,6 +39,20 @@ def _validate_genome_accession(accession: str) -> str:
             f"Invalid genome accession format: {accession}. " f"Expected format: GCF_000000000.0 or GCA_000000000.0"
         )
     return accession
+
+
+def genome_fasta_path(accession: str, output_dir: Path) -> Path:
+    """Return the organized FASTA path an accession is extracted to."""
+    return Path(output_dir) / f"{accession}.fna"
+
+
+def partition_present_genomes(accessions: List[str], output_dir: Path) -> Tuple[List[str], List[str]]:
+    """Split accessions into (already present on disk, missing) by their .fna file."""
+    present: List[str] = []
+    missing: List[str] = []
+    for acc in accessions:
+        (present if genome_fasta_path(acc, output_dir).exists() else missing).append(acc)
+    return present, missing
 
 
 def check_datasets_available() -> bool:

--- a/metaquest/data/sra.py
+++ b/metaquest/data/sra.py
@@ -28,6 +28,17 @@ def _safe_rmtree(path: Path) -> None:
         logger.warning(f"Could not remove directory {path}: {e}")
 
 
+def accession_has_fastq(acc_dir: Union[str, Path]) -> bool:
+    """Return True if the per-accession directory holds at least one FASTQ file.
+
+    This is the single source of truth for "this accession is already
+    downloaded" used across the download and status paths (a per-accession
+    subdirectory containing any ``*.fastq*`` file).
+    """
+    acc_path = Path(acc_dir)
+    return acc_path.is_dir() and any(acc_path.glob("*.fastq*"))
+
+
 def _read_blacklist_files(blacklist_files):
     """
     Read accessions from blacklist files.
@@ -119,8 +130,7 @@ def _check_existing_download(output_path, force):
         return False
 
     if not force and output_path.exists():
-        fastq_files = list(output_path.glob("*.fastq*"))
-        if fastq_files:
+        if accession_has_fastq(output_path):
             return True
 
         # Found empty directory, will redownload
@@ -278,14 +288,8 @@ def _check_existing_downloads(
             blacklisted.append(acc)
             continue
 
-        acc_path = fastq_path / acc
-        if not force and acc_path.exists():
-            fastq_files = list(acc_path.glob("*.fastq*"))
-            if fastq_files:
-                already_downloaded.append(acc)
-            else:
-                # Folder exists but no FASTQ files, needs download
-                to_download.append(acc)
+        if not force and accession_has_fastq(fastq_path / acc):
+            already_downloaded.append(acc)
         else:
             to_download.append(acc)
 

--- a/tests/test_cli_genome.py
+++ b/tests/test_cli_genome.py
@@ -200,6 +200,8 @@ class TestGenomeDownloadCommand:
             output_dir="genomes/",
             representative_only=True,
             assembly_level=None,
+            force=False,
+            dry_run=False,
         )
         result = cmd.execute(args)
         assert result == 1
@@ -219,6 +221,8 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 0
@@ -242,6 +246,8 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 0
@@ -263,6 +269,8 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 0
@@ -278,6 +286,8 @@ class TestGenomeDownloadCommand:
             output_dir="genomes/",
             representative_only=True,
             assembly_level=None,
+            force=False,
+            dry_run=False,
         )
         result = cmd.execute(args)
         assert result == 1
@@ -295,9 +305,77 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 1
+
+    @patch("metaquest.cli.commands.genome.extract_and_organize")
+    @patch("metaquest.cli.commands.genome.download_genomes")
+    def test_execute_skips_present_genome(self, mock_download, mock_extract):
+        cmd = GenomeDownloadCommand()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "GCF_000006945.2.fna").write_text(">seq\nACGT\n")
+            args = argparse.Namespace(
+                accessions=["GCF_000006945.2"],
+                accession_file=None,
+                species=None,
+                genus=None,
+                output_dir=tmpdir,
+                representative_only=True,
+                assembly_level=None,
+                force=False,
+                dry_run=False,
+            )
+            result = cmd.execute(args)
+            assert result == 0
+            mock_download.assert_not_called()
+            mock_extract.assert_not_called()
+
+    @patch("metaquest.cli.commands.genome.extract_and_organize")
+    @patch("metaquest.cli.commands.genome.download_genomes")
+    def test_execute_force_redownloads_present_genome(self, mock_download, mock_extract):
+        mock_download.return_value = Path("genomes/download.zip")
+        mock_extract.return_value = {"GCF_000006945.2": Path("genomes/GCF_000006945.2.fna")}
+        cmd = GenomeDownloadCommand()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "GCF_000006945.2.fna").write_text(">seq\nACGT\n")
+            args = argparse.Namespace(
+                accessions=["GCF_000006945.2"],
+                accession_file=None,
+                species=None,
+                genus=None,
+                output_dir=tmpdir,
+                representative_only=True,
+                assembly_level=None,
+                force=True,
+                dry_run=False,
+            )
+            result = cmd.execute(args)
+            assert result == 0
+            mock_download.assert_called_once()
+
+    @patch("metaquest.cli.commands.genome.extract_and_organize")
+    @patch("metaquest.cli.commands.genome.download_genomes")
+    def test_execute_dry_run_downloads_nothing(self, mock_download, mock_extract):
+        cmd = GenomeDownloadCommand()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "GCF_000006945.2.fna").write_text(">seq\nACGT\n")
+            args = argparse.Namespace(
+                accessions=["GCF_000006945.2", "GCF_000007545.1"],
+                accession_file=None,
+                species=None,
+                genus=None,
+                output_dir=tmpdir,
+                representative_only=True,
+                assembly_level=None,
+                force=False,
+                dry_run=True,
+            )
+            result = cmd.execute(args)
+            assert result == 0
+            mock_download.assert_not_called()
 
 
 class TestGenomePrepareCommand:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -45,6 +45,7 @@ class TestRegisterAllCommands:
             "plot_metadata_counts",
             "download_sra",
             "assemble_datasets",
+            "status",
             "sra_info",
             "sra_download",
             "sra_stats",

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,124 @@
+"""Tests for the `status` (local inventory) CLI command."""
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+from metaquest.cli.commands.status import StatusCommand
+
+
+def _args(**kwargs):
+    base = dict(
+        fastq_folder="fastq",
+        metadata_folder="metadata",
+        genomes_folder="genomes",
+        accessions_file=None,
+        parsed_containment=None,
+        list_missing=False,
+        json=False,
+    )
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _make_tree(tmp):
+    """Create a small fixture tree: one accession fully present, one absent."""
+    root = Path(tmp)
+    (root / "fastq" / "SRR1").mkdir(parents=True)
+    (root / "fastq" / "SRR1" / "SRR1.fastq.gz").write_text("@r\nACGT\n+\nIIII\n")
+    (root / "metadata").mkdir()
+    (root / "metadata" / "SRR1_metadata.xml").write_text("<xml/>")
+    (root / "genomes").mkdir()
+    (root / "genomes" / "GCF_000006945.2.fna").write_text(">s\nACGT\n")
+    return root
+
+
+class TestStatusCommand:
+    def test_command_properties(self):
+        cmd = StatusCommand()
+        assert cmd.name == "status"
+        assert "local" in cmd.help.lower()
+
+    def test_on_disk_inventory(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                )
+            )
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "FASTQ accessions on disk : 1" in out
+        assert "Metadata XML on disk     : 1" in out
+        assert "Genome FASTA on disk     : 1" in out
+
+    def test_reconcile_present_and_missing(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            accs = root / "accs.txt"
+            accs.write_text("SRR1\nSRR2\n")
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                    accessions_file=str(accs),
+                    list_missing=True,
+                )
+            )
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "FASTQ    : 1 present, 1 missing" in out
+        assert "Metadata : 1 present, 1 missing" in out
+        assert "SRR2" in out
+
+    def test_json_output(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            accs = root / "accs.txt"
+            accs.write_text("SRR1\nSRR2\n")
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                    accessions_file=str(accs),
+                    json=True,
+                )
+            )
+        assert result == 0
+        report = json.loads(capsys.readouterr().out)
+        assert report["on_disk"]["fastq_accessions"] == 1
+        assert report["wanted"]["total"] == 2
+        assert report["wanted"]["fastq_missing"] == ["SRR2"]
+
+    def test_parsed_containment_supplies_wanted_list(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            table = root / "parsed_containment.txt"
+            table.write_text("accession\tGCF_x\nSRR1\t0.9\nSRR2\t0.4\n")
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                    parsed_containment=str(table),
+                    json=True,
+                )
+            )
+        assert result == 0
+        report = json.loads(capsys.readouterr().out)
+        assert report["wanted"]["total"] == 2
+
+    def test_missing_accessions_file_errors(self):
+        cmd = StatusCommand()
+        result = cmd.execute(_args(accessions_file="/nonexistent/accs.txt"))
+        assert result == 1


### PR DESCRIPTION
## Summary

Phase 2 of the pipeline-usability work (stacked on #36). Makes it easy to see what MetaQuest already has locally so nothing is re-downloaded.

- **New `metaquest status` command** (`cli/commands/status.py`): reports the on-disk inventory (FASTQ accessions, metadata XML, genome FASTA) and, given a wanted list via `--accessions-file` or `--parsed-containment`, reconciles present-vs-missing per data type. Supports `--list-missing` and `--json`. Folder locations are overridable with `--fastq-folder` / `--metadata-folder` / `--genomes-folder`.
- **Genome download now skips existing files**: `genome_download` drops accessions whose `<GCF>.fna` already exists; adds `--force` to re-download and `--dry-run` to report present-vs-missing without downloading. Backed by `partition_present_genomes()` / `genome_fasta_path()` in `data/genome_download.py`.
- **Dedup SRA skip logic**: both `_check_existing_download` and `_check_existing_downloads` now share a single `accession_has_fastq()` helper.

## Testing

- New `tests/test_cli_status.py` (inventory, reconcile, JSON, parsed-containment, error path).
- New genome tests for skip / `--force` / `--dry-run`; existing genome-download tests updated for the new args.
- Full suite green (1211 passed); `make check` clean.

Base is `fix/cli-command-logic`; GitHub will retarget to `main` once #36 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)