### PR TITLE
Targeted read extraction before assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,27 @@ re-download or `--dry-run` to report present-vs-missing without downloading:
 metaquest genome_download --accessions GCF_000006945.2 --dry-run
 ```
 
+### 11. Targeted Read Extraction Before Assembly
+
+To assemble only the reads relevant to a target genome (a small, targeted assembly rather than a
+whole-metagenome assembly), use `extract_target_reads`. For every sample whose containment for the
+target genome meets the threshold, it maps the reads with minimap2 and keeps the mapped reads with
+samtools, writing them to `targeted/<ACC>/`:
+
+```bash
+metaquest extract_target_reads \
+  --parsed-containment parsed_containment.txt \
+  --genome-id GCF_000006945.2 \
+  --genome-fasta genomes/GCF_000006945.2.fna \
+  --fastq-folder fastq --output-folder targeted \
+  --threshold 0.5 --preset sr
+```
+
+Use `--dry-run` to list the qualifying samples without running any tool, `--preset` to match the read
+type (`sr` for Illumina, `map-ont`/`map-pb`/`map-hifi` for long reads), and `--assemble` to run
+megahit on each sample's extracted reads. This step requires `minimap2`, `samtools`, and (for
+`--assemble`) `megahit` to be installed and on the PATH.
+
 ## Advanced SRA Operations
 
 ### Which SRA download command should I use?

--- a/README.md
+++ b/README.md
@@ -127,6 +127,25 @@ To analyze a single sample from the summary, you can use the `single_sample` com
 metaquest single_sample --summary-file parsed_containment.txt --metadata-file parsed_metadata.txt --summary-column GCF_000008985.1 --metadata-column Sample_Scientific_Name --threshold 0.95
 ```
 
+### 10. Checking What Is Already Available Locally
+
+Before downloading, use `status` to see which reads, metadata, and genomes are already present
+so nothing is fetched twice. Given a wanted list it also reports what is still missing:
+
+```bash
+metaquest status --accessions-file accessions.txt --list-missing
+metaquest status --parsed-containment parsed_containment.txt --json
+```
+
+The command reconciles against the standard layout (`fastq/<ACC>/`, `metadata/<ACC>_metadata.xml`,
+`genomes/<GCF>.fna`); override the locations with `--fastq-folder`, `--metadata-folder`, and
+`--genomes-folder`. Genome downloads skip accessions whose FASTA already exists; pass `--force` to
+re-download or `--dry-run` to report present-vs-missing without downloading:
+
+```bash
+metaquest genome_download --accessions GCF_000006945.2 --dry-run
+```
+
 ## Advanced SRA Operations
 
 ### Which SRA download command should I use?

--- a/metaquest/cli/commands/__init__.py
+++ b/metaquest/cli/commands/__init__.py
@@ -16,6 +16,7 @@ from .metadata import (
 from .samples import SingleSampleCommand
 from .sra import DownloadSraCommand, AssembleDatasetsCommand
 from .status import StatusCommand
+from .read_extraction import ExtractTargetReadsCommand
 from .test_data import DownloadTestGenomeCommand
 from .genome import GenomeSearchCommand, GenomeDownloadCommand, GenomePrepareCommand
 from .explore import (
@@ -38,6 +39,7 @@ __all__ = [
     "DownloadSraCommand",
     "AssembleDatasetsCommand",
     "StatusCommand",
+    "ExtractTargetReadsCommand",
     "DownloadTestGenomeCommand",
     "GenomeSearchCommand",
     "GenomeDownloadCommand",

--- a/metaquest/cli/commands/__init__.py
+++ b/metaquest/cli/commands/__init__.py
@@ -15,6 +15,7 @@ from .metadata import (
 )
 from .samples import SingleSampleCommand
 from .sra import DownloadSraCommand, AssembleDatasetsCommand
+from .status import StatusCommand
 from .test_data import DownloadTestGenomeCommand
 from .genome import GenomeSearchCommand, GenomeDownloadCommand, GenomePrepareCommand
 from .explore import (
@@ -36,6 +37,7 @@ __all__ = [
     "SingleSampleCommand",
     "DownloadSraCommand",
     "AssembleDatasetsCommand",
+    "StatusCommand",
     "DownloadTestGenomeCommand",
     "GenomeSearchCommand",
     "GenomeDownloadCommand",

--- a/metaquest/cli/commands/genome.py
+++ b/metaquest/cli/commands/genome.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from metaquest.cli.base import BaseCommand
 from metaquest.core.exceptions import MetaQuestError
-from metaquest.data.genome_download import download_genomes, extract_and_organize
+from metaquest.data.genome_download import download_genomes, extract_and_organize, partition_present_genomes
 from metaquest.data.gtdb import (
     get_accessions_for_genus,
     get_accessions_for_species,
@@ -136,6 +136,16 @@ class GenomeDownloadCommand(BaseCommand):
             default=None,
             help="Filter by assembly level",
         )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-download genomes even if their FASTA already exists",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report which genomes are already present vs would be downloaded, without downloading",
+        )
 
     def _collect_accessions(self, args: argparse.Namespace) -> list:
         """Collect accessions from all input sources."""
@@ -177,10 +187,21 @@ class GenomeDownloadCommand(BaseCommand):
             output_dir = Path(args.output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
 
-            self.logger.info("Downloading %d genome(s) to %s", len(accessions), output_dir)
+            present, missing = partition_present_genomes(accessions, output_dir)
+            to_download = accessions if args.force else missing
 
+            if present and not args.force:
+                self.logger.info("%d genome(s) already present, skipping", len(present))
+            if args.dry_run:
+                self.logger.info("Dry run: %d already present, %d would be downloaded", len(present), len(to_download))
+                return 0
+            if not to_download:
+                self.logger.info("All %d genome(s) already present", len(accessions))
+                return 0
+
+            self.logger.info("Downloading %d genome(s) to %s", len(to_download), output_dir)
             zip_path = download_genomes(
-                accessions,
+                to_download,
                 output_dir,
                 assembly_level=args.assembly_level,
             )

--- a/metaquest/cli/commands/read_extraction.py
+++ b/metaquest/cli/commands/read_extraction.py
@@ -1,0 +1,84 @@
+"""CLI command for targeted read extraction before assembly."""
+
+import argparse
+from pathlib import Path
+
+from metaquest.cli.base import BaseCommand
+from metaquest.core.exceptions import MetaQuestError
+from metaquest.data.read_extraction import (
+    MINIMAP2_PRESETS,
+    assemble_extracted_reads,
+    extract_target_reads,
+)
+
+
+class ExtractTargetReadsCommand(BaseCommand):
+    """Map each sample's reads to a target genome and keep only the mapped reads."""
+
+    @property
+    def name(self) -> str:
+        return "extract_target_reads"
+
+    @property
+    def help(self) -> str:
+        return "Filter reads that map to a target genome for a small, targeted assembly"
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--parsed-containment",
+            required=True,
+            help="Parsed containment table (samples x genomes) from parse_containment",
+        )
+        parser.add_argument("--genome-id", required=True, help="Target genome column to extract against")
+        parser.add_argument("--genome-fasta", required=True, help="FASTA file for the target genome")
+        parser.add_argument("--fastq-folder", default="fastq", help="Root folder of per-accession FASTQ files")
+        parser.add_argument("--output-folder", default="targeted", help="Root folder for the extracted reads")
+        parser.add_argument(
+            "--threshold", type=float, default=0.1, help="Minimum containment for a sample to be included"
+        )
+        parser.add_argument(
+            "--preset", choices=sorted(MINIMAP2_PRESETS), default="sr", help="minimap2 preset for the read type"
+        )
+        parser.add_argument("--threads", type=int, default=4, help="Threads for minimap2 and samtools")
+        parser.add_argument(
+            "--assemble", action="store_true", help="Assemble each sample's extracted reads with megahit"
+        )
+        parser.add_argument("--min-contig-len", type=int, default=None, help="megahit minimum contig length")
+        parser.add_argument(
+            "--dry-run", action="store_true", help="List the qualifying samples without running any tool"
+        )
+
+    def execute(self, args: argparse.Namespace) -> int:
+        try:
+            results = extract_target_reads(
+                parsed_containment=args.parsed_containment,
+                genome_id=args.genome_id,
+                genome_fasta=args.genome_fasta,
+                fastq_folder=args.fastq_folder,
+                output_folder=args.output_folder,
+                threshold=args.threshold,
+                preset=args.preset,
+                threads=args.threads,
+                dry_run=args.dry_run,
+            )
+
+            if args.dry_run:
+                self.logger.info("Dry run: %d sample(s) would be extracted for %s", len(results), args.genome_id)
+                for accession in results:
+                    self.logger.info("  %s", accession)
+                return 0
+
+            self.logger.info("Extracted reads for %d sample(s)", len(results))
+
+            if args.assemble:
+                for accession, reads in results.items():
+                    if not reads:
+                        continue
+                    out_dir = Path(args.output_folder) / accession / f"{args.genome_id}_assembly"
+                    assemble_extracted_reads(reads, out_dir, threads=args.threads, min_contig_len=args.min_contig_len)
+                self.logger.info("Assembled %d sample(s)", len(results))
+
+            return 0
+        except MetaQuestError as e:
+            self.logger.error("Error extracting target reads: %s", e)
+            return 1

--- a/metaquest/cli/commands/status.py
+++ b/metaquest/cli/commands/status.py
@@ -1,0 +1,132 @@
+"""Local inventory / status CLI command.
+
+Reports what MetaQuest has already downloaded locally (SRA reads, NCBI metadata,
+genome assemblies) so a user can see what is available without re-downloading,
+and optionally reconciles that against a wanted list of accessions.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+from metaquest.cli.base import BaseCommand
+from metaquest.core.exceptions import MetaQuestError
+from metaquest.data.sra import accession_has_fastq
+
+
+class StatusCommand(BaseCommand):
+    """Command to report locally available data and reconcile it against a wanted list."""
+
+    @property
+    def name(self) -> str:
+        return "status"
+
+    @property
+    def help(self) -> str:
+        return "Report which SRA reads, metadata, and genomes are already available locally"
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--fastq-folder", default="fastq", help="Folder holding per-accession FASTQ downloads")
+        parser.add_argument("--metadata-folder", default="metadata", help="Folder holding NCBI metadata XML")
+        parser.add_argument("--genomes-folder", default="genomes", help="Folder holding genome FASTA files")
+        parser.add_argument(
+            "--accessions-file",
+            help="Optional file of SRA accessions (one per line) to reconcile against local FASTQ/metadata",
+        )
+        parser.add_argument(
+            "--parsed-containment",
+            help="Optional parsed containment table; its sample accessions are the wanted list",
+        )
+        parser.add_argument("--list-missing", action="store_true", help="Also print the accessions that are missing")
+        parser.add_argument("--json", action="store_true", help="Emit the report as JSON")
+
+    def _wanted_accessions(self, args: argparse.Namespace) -> List[str]:
+        """Load the wanted accession list from a file and/or a parsed containment table."""
+        wanted: List[str] = []
+        if args.accessions_file:
+            path = Path(args.accessions_file)
+            if not path.exists():
+                raise MetaQuestError(f"Accessions file not found: {path}")
+            wanted += [ln.strip() for ln in path.read_text().splitlines() if ln.strip() and not ln.startswith("#")]
+        if args.parsed_containment:
+            import pandas as pd
+
+            path = Path(args.parsed_containment)
+            if not path.exists():
+                raise MetaQuestError(f"Parsed containment file not found: {path}")
+            wanted += [str(i) for i in pd.read_csv(path, sep="\t", index_col=0).index]
+        # de-duplicate, preserve order
+        return list(dict.fromkeys(wanted))
+
+    @staticmethod
+    def _reconcile(wanted: List[str], present_fn) -> Tuple[List[str], List[str]]:
+        """Split a wanted list into (present, missing) using a predicate."""
+        present = [a for a in wanted if present_fn(a)]
+        missing = [a for a in wanted if a not in present]
+        return present, missing
+
+    def _build_report(self, args: argparse.Namespace) -> dict:
+        fastq_dir = Path(args.fastq_folder)
+        meta_dir = Path(args.metadata_folder)
+        genomes_dir = Path(args.genomes_folder)
+
+        if fastq_dir.is_dir():
+            on_disk_fastq = sorted(d.name for d in fastq_dir.iterdir() if accession_has_fastq(d))
+        else:
+            on_disk_fastq = []
+        on_disk_meta = sorted(p.name[: -len("_metadata.xml")] for p in meta_dir.glob("*_metadata.xml"))
+        genome_globs = ("*.fna", "*.fna.gz", "*.fasta", "*.fasta.gz", "*.fa", "*.fa.gz")
+        on_disk_genomes = sorted({p.name for g in genome_globs for p in genomes_dir.glob(g)})
+
+        report: dict = {
+            "on_disk": {
+                "fastq_accessions": len(on_disk_fastq),
+                "metadata_xml": len(on_disk_meta),
+                "genome_fasta": len(on_disk_genomes),
+            }
+        }
+
+        wanted = self._wanted_accessions(args)
+        if wanted:
+            fastq_present, fastq_missing = self._reconcile(wanted, lambda a: accession_has_fastq(fastq_dir / a))
+            meta_present, meta_missing = self._reconcile(wanted, lambda a: (meta_dir / f"{a}_metadata.xml").exists())
+            report["wanted"] = {
+                "total": len(wanted),
+                "fastq_present": len(fastq_present),
+                "fastq_missing": fastq_missing,
+                "metadata_present": len(meta_present),
+                "metadata_missing": meta_missing,
+            }
+        return report
+
+    def _print_report(self, report: dict, list_missing: bool) -> None:
+        od = report["on_disk"]
+        print("Local inventory")
+        print("===============")
+        print(f"  FASTQ accessions on disk : {od['fastq_accessions']}")
+        print(f"  Metadata XML on disk     : {od['metadata_xml']}")
+        print(f"  Genome FASTA on disk     : {od['genome_fasta']}")
+
+        w = report.get("wanted")
+        if w:
+            print(f"\nReconciled against {w['total']} wanted accession(s)")
+            print(f"  FASTQ    : {w['fastq_present']} present, {len(w['fastq_missing'])} missing")
+            print(f"  Metadata : {w['metadata_present']} present, {len(w['metadata_missing'])} missing")
+            if list_missing:
+                if w["fastq_missing"]:
+                    print("  Missing FASTQ    : " + ", ".join(w["fastq_missing"]))
+                if w["metadata_missing"]:
+                    print("  Missing metadata : " + ", ".join(w["metadata_missing"]))
+
+    def execute(self, args: argparse.Namespace) -> int:
+        try:
+            report = self._build_report(args)
+            if args.json:
+                print(json.dumps(report, indent=2))
+            else:
+                self._print_report(report, args.list_missing)
+            return 0
+        except MetaQuestError as e:
+            self.logger.error(f"Error building status report: {e}")
+            return 1

--- a/metaquest/cli/main.py
+++ b/metaquest/cli/main.py
@@ -29,6 +29,7 @@ from metaquest.cli.commands import (
     SingleSampleCommand,
     DownloadSraCommand,
     AssembleDatasetsCommand,
+    StatusCommand,
     DownloadTestGenomeCommand,
     GenomeSearchCommand,
     GenomeDownloadCommand,
@@ -73,6 +74,7 @@ def register_all_commands() -> None:
         PlotMetadataCountsCommand(),
         DownloadSraCommand(),
         AssembleDatasetsCommand(),
+        StatusCommand(),
         # Enhanced SRA commands
         SRAInfoCommand(),
         SRADownloadEnhancedCommand(),

--- a/metaquest/cli/main.py
+++ b/metaquest/cli/main.py
@@ -30,6 +30,7 @@ from metaquest.cli.commands import (
     DownloadSraCommand,
     AssembleDatasetsCommand,
     StatusCommand,
+    ExtractTargetReadsCommand,
     DownloadTestGenomeCommand,
     GenomeSearchCommand,
     GenomeDownloadCommand,
@@ -75,6 +76,7 @@ def register_all_commands() -> None:
         DownloadSraCommand(),
         AssembleDatasetsCommand(),
         StatusCommand(),
+        ExtractTargetReadsCommand(),
         # Enhanced SRA commands
         SRAInfoCommand(),
         SRADownloadEnhancedCommand(),

--- a/metaquest/core/constants.py
+++ b/metaquest/core/constants.py
@@ -77,6 +77,7 @@ ALLOWED_BIOINFORMATICS_TOOLS = {
         "safe_params": {
             "-1",
             "-2",
+            "-r",
             "-o",
             "--num-cpu-threads",
             "--memory",
@@ -121,6 +122,34 @@ ALLOWED_BIOINFORMATICS_TOOLS = {
             "--no-progressbar",
         },
         "description": "NCBI datasets CLI for genome downloads",
+    },
+    "minimap2": {
+        "safe_params": {
+            "-a",
+            "-x",
+            "-t",
+            "-o",
+            "--secondary",
+            "--version",
+        },
+        "description": "Read-to-reference aligner (targeted read extraction)",
+    },
+    "samtools": {
+        "safe_params": {
+            "view",
+            "fastq",
+            "-b",
+            "-F",
+            "-f",
+            "-o",
+            "-0",
+            "-1",
+            "-2",
+            "-s",
+            "-@",
+            "--version",
+        },
+        "description": "SAM/BAM utilities (filter and export mapped reads)",
     },
 }
 

--- a/metaquest/data/genome_download.py
+++ b/metaquest/data/genome_download.py
@@ -11,7 +11,7 @@ import re
 import shutil
 import zipfile
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from metaquest.core.constants import GENOME_ACCESSION_PATTERN, GENOME_ACCESSION_PREFIXES
 from metaquest.core.exceptions import DataAccessError
@@ -39,6 +39,20 @@ def _validate_genome_accession(accession: str) -> str:
             f"Invalid genome accession format: {accession}. " f"Expected format: GCF_000000000.0 or GCA_000000000.0"
         )
     return accession
+
+
+def genome_fasta_path(accession: str, output_dir: Path) -> Path:
+    """Return the organized FASTA path an accession is extracted to."""
+    return Path(output_dir) / f"{accession}.fna"
+
+
+def partition_present_genomes(accessions: List[str], output_dir: Path) -> Tuple[List[str], List[str]]:
+    """Split accessions into (already present on disk, missing) by their .fna file."""
+    present: List[str] = []
+    missing: List[str] = []
+    for acc in accessions:
+        (present if genome_fasta_path(acc, output_dir).exists() else missing).append(acc)
+    return present, missing
 
 
 def check_datasets_available() -> bool:

--- a/metaquest/data/read_extraction.py
+++ b/metaquest/data/read_extraction.py
@@ -1,0 +1,213 @@
+"""Targeted read extraction prior to assembly.
+
+Given a parsed containment table (samples x target genomes), this module maps
+each sample's reads against a chosen target genome and keeps only the reads that
+align. The resulting reduced FASTQ set supports a small, targeted assembly rather
+than a whole-metagenome assembly.
+
+The mapping uses minimap2 (one aligner for both short and long reads) and samtools
+to filter and export the mapped reads. External tools run through
+``SecureSubprocess.run_secure`` and must be present on the system.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import pandas as pd
+
+from metaquest.core.exceptions import DataAccessError, ProcessingError
+from metaquest.data.file_io import ensure_directory
+from metaquest.utils.security import SecureSubprocess
+
+logger = logging.getLogger(__name__)
+
+# minimap2 presets by read type; keys are accepted on the CLI via --preset
+MINIMAP2_PRESETS = {
+    "sr": "sr",  # short paired/single Illumina reads
+    "map-ont": "map-ont",  # Oxford Nanopore
+    "map-pb": "map-pb",  # PacBio CLR
+    "map-hifi": "map-hifi",  # PacBio HiFi
+}
+
+
+def select_samples_for_genome(containment: pd.DataFrame, genome_id: str, threshold: float) -> List[str]:
+    """Return the sample accessions whose containment for a genome meets a threshold.
+
+    Args:
+        containment: Parsed containment table indexed by sample accession.
+        genome_id: Target genome column to select on.
+        threshold: Minimum containment value (inclusive).
+
+    Raises:
+        ProcessingError: If the genome column is absent from the table.
+    """
+    if genome_id not in containment.columns:
+        raise ProcessingError(
+            f"Genome '{genome_id}' not found in the containment table. "
+            f"Available columns include: {', '.join(map(str, containment.columns[:5]))}"
+        )
+    values = pd.to_numeric(containment[genome_id], errors="coerce")
+    return [str(acc) for acc in containment.index[values >= threshold]]
+
+
+def _sample_reads(fastq_folder: Path, accession: str) -> List[Path]:
+    """Return the FASTQ files for one accession, sorted (R1 before R2)."""
+    acc_dir = fastq_folder / accession
+    if not acc_dir.is_dir():
+        return []
+    return sorted(p for p in acc_dir.glob("*.fastq*") if p.is_file())
+
+
+def _map_and_extract(
+    accession: str,
+    reads: List[Path],
+    genome_fasta: Path,
+    out_dir: Path,
+    genome_id: str,
+    preset: str,
+    threads: int,
+) -> List[Path]:
+    """Map one sample's reads to the target genome and write the mapped reads.
+
+    Returns the list of FASTQ files written (two for paired input, one otherwise).
+    Intermediate SAM/BAM files are removed on success.
+    """
+    ensure_directory(out_dir)
+    sam_path = out_dir / f"{genome_id}.sam"
+    bam_path = out_dir / f"{genome_id}.mapped.bam"
+
+    # 1. Align reads to the reference (SAM output).
+    minimap_args = ["-a", "-x", preset, "-t", str(threads), "-o", str(sam_path), str(genome_fasta)]
+    minimap_args.extend(str(r) for r in reads)
+    SecureSubprocess.run_secure("minimap2", minimap_args)
+
+    # 2. Keep only mapped records (-F 4 drops the unmapped flag).
+    SecureSubprocess.run_secure(
+        "samtools", ["view", "-b", "-F", "4", "-@", str(threads), "-o", str(bam_path), str(sam_path)]
+    )
+
+    # 3. Export mapped reads back to FASTQ.
+    if len(reads) >= 2:
+        out1 = out_dir / f"{genome_id}_1.fastq.gz"
+        out2 = out_dir / f"{genome_id}_2.fastq.gz"
+        singles = out_dir / f"{genome_id}_s.fastq.gz"
+        SecureSubprocess.run_secure(
+            "samtools", ["fastq", "-1", str(out1), "-2", str(out2), "-s", str(singles), str(bam_path)]
+        )
+        written = [out1, out2]
+    else:
+        out0 = out_dir / f"{genome_id}.fastq.gz"
+        SecureSubprocess.run_secure("samtools", ["fastq", "-0", str(out0), str(bam_path)])
+        written = [out0]
+
+    # Remove intermediates; the reduced FASTQ set is the deliverable.
+    for tmp in (sam_path, bam_path):
+        tmp.unlink(missing_ok=True)
+
+    return written
+
+
+def extract_target_reads(
+    parsed_containment: Union[str, Path],
+    genome_id: str,
+    genome_fasta: Union[str, Path],
+    fastq_folder: Union[str, Path] = "fastq",
+    output_folder: Union[str, Path] = "targeted",
+    threshold: float = 0.1,
+    preset: str = "sr",
+    threads: int = 4,
+    dry_run: bool = False,
+) -> Dict[str, List[Path]]:
+    """Extract reads mapping to a target genome for every qualifying sample.
+
+    Args:
+        parsed_containment: Parsed containment table (samples x genomes).
+        genome_id: Target genome to extract against (a column in the table).
+        genome_fasta: FASTA file for the target genome.
+        fastq_folder: Root folder with per-accession FASTQ subdirectories.
+        output_folder: Root folder for the extracted reads (per-accession subdirs).
+        threshold: Minimum containment for a sample to be included.
+        preset: minimap2 preset (sr, map-ont, map-pb, map-hifi).
+        threads: Threads for minimap2 and samtools.
+        dry_run: If True, report the qualifying samples without running any tool.
+
+    Returns:
+        Mapping of accession to the list of FASTQ files written (empty in dry-run).
+
+    Raises:
+        DataAccessError: If inputs are missing.
+        ProcessingError: If the genome column or preset is invalid.
+    """
+    table_path = Path(parsed_containment)
+    if not table_path.exists():
+        raise DataAccessError(f"Parsed containment table not found: {table_path}")
+    if preset not in MINIMAP2_PRESETS:
+        raise ProcessingError(f"Unknown minimap2 preset '{preset}'. Choose one of: {', '.join(MINIMAP2_PRESETS)}")
+
+    fastq_root = Path(fastq_folder)
+    genome_path = Path(genome_fasta)
+    if not dry_run and not genome_path.exists():
+        raise DataAccessError(f"Target genome FASTA not found: {genome_path}")
+
+    containment = pd.read_csv(table_path, sep="\t", index_col=0)
+    samples = select_samples_for_genome(containment, genome_id, threshold)
+    logger.info("%d sample(s) meet containment >= %.3f for %s", len(samples), threshold, genome_id)
+
+    results: Dict[str, List[Path]] = {}
+    output_root = Path(output_folder)
+
+    for accession in samples:
+        reads = _sample_reads(fastq_root, accession)
+        if not reads:
+            logger.warning("No FASTQ files found for %s under %s; skipping", accession, fastq_root)
+            continue
+        if dry_run:
+            results[accession] = []
+            continue
+        written = _map_and_extract(accession, reads, genome_path, output_root / accession, genome_id, preset, threads)
+        results[accession] = written
+        logger.info("Extracted mapped reads for %s -> %s", accession, ", ".join(str(p) for p in written))
+
+    return results
+
+
+def assemble_extracted_reads(
+    reads: List[Path],
+    output_dir: Union[str, Path],
+    threads: int = 4,
+    min_contig_len: Optional[int] = None,
+) -> Path:
+    """Assemble a set of extracted FASTQ files with megahit.
+
+    Single-end input (one file) uses megahit ``-r``; paired input (two files) uses
+    ``-1``/``-2``. The reads are expected to be a small, target-filtered set.
+
+    Args:
+        reads: One or two FASTQ files to assemble.
+        output_dir: megahit output directory (must not already exist).
+        threads: CPU threads.
+        min_contig_len: Optional minimum contig length.
+
+    Returns:
+        Path to the megahit output directory.
+
+    Raises:
+        ProcessingError: If the number of reads is unsupported.
+    """
+    out_dir = Path(output_dir)
+    args: List[str] = []
+    if len(reads) == 2:
+        args += ["-1", str(reads[0]), "-2", str(reads[1])]
+    elif len(reads) == 1:
+        args += ["-r", str(reads[0])]
+    else:
+        raise ProcessingError(f"Expected 1 or 2 FASTQ files to assemble, got {len(reads)}")
+
+    args += ["--num-cpu-threads", str(threads), "-o", str(out_dir)]
+    if min_contig_len is not None:
+        args += ["--min-contig-len", str(min_contig_len)]
+
+    SecureSubprocess.run_secure("megahit", args)
+    logger.info("Assembly written to %s", out_dir)
+    return out_dir

--- a/metaquest/data/sra.py
+++ b/metaquest/data/sra.py
@@ -618,15 +618,20 @@ def _find_paired_reads(illumina_files):
     """
     read_pairs = []
 
+    # Accept both the "R1/R2" convention and fasterq-dump's "_1/_2" split-files output.
+    r1_markers = ("R1", "_1")
     for fastq_file in illumina_files:
-        if "R1" in fastq_file.name:
-            # Find paired read file
-            r2_file = fastq_file.with_name(fastq_file.name.replace("R1", "R2"))
+        marker = next((m for m in r1_markers if m in fastq_file.name), None)
+        if marker is None:
+            continue
 
-            if r2_file.exists():
-                read_pairs.append((fastq_file, r2_file))
-            else:
-                logger.warning(f"Could not find paired read file for {fastq_file}")
+        mate_marker = marker.replace("1", "2")
+        r2_file = fastq_file.with_name(fastq_file.name.replace(marker, mate_marker))
+
+        if r2_file.exists():
+            read_pairs.append((fastq_file, r2_file))
+        else:
+            logger.warning(f"Could not find paired read file for {fastq_file}")
 
     return read_pairs
 

--- a/metaquest/data/sra.py
+++ b/metaquest/data/sra.py
@@ -28,6 +28,17 @@ def _safe_rmtree(path: Path) -> None:
         logger.warning(f"Could not remove directory {path}: {e}")
 
 
+def accession_has_fastq(acc_dir: Union[str, Path]) -> bool:
+    """Return True if the per-accession directory holds at least one FASTQ file.
+
+    This is the single source of truth for "this accession is already
+    downloaded" used across the download and status paths (a per-accession
+    subdirectory containing any ``*.fastq*`` file).
+    """
+    acc_path = Path(acc_dir)
+    return acc_path.is_dir() and any(acc_path.glob("*.fastq*"))
+
+
 def _read_blacklist_files(blacklist_files):
     """
     Read accessions from blacklist files.
@@ -119,8 +130,7 @@ def _check_existing_download(output_path, force):
         return False
 
     if not force and output_path.exists():
-        fastq_files = list(output_path.glob("*.fastq*"))
-        if fastq_files:
+        if accession_has_fastq(output_path):
             return True
 
         # Found empty directory, will redownload
@@ -278,14 +288,8 @@ def _check_existing_downloads(
             blacklisted.append(acc)
             continue
 
-        acc_path = fastq_path / acc
-        if not force and acc_path.exists():
-            fastq_files = list(acc_path.glob("*.fastq*"))
-            if fastq_files:
-                already_downloaded.append(acc)
-            else:
-                # Folder exists but no FASTQ files, needs download
-                to_download.append(acc)
+        if not force and accession_has_fastq(fastq_path / acc):
+            already_downloaded.append(acc)
         else:
             to_download.append(acc)
 

--- a/tests/test_cli_genome.py
+++ b/tests/test_cli_genome.py
@@ -200,6 +200,8 @@ class TestGenomeDownloadCommand:
             output_dir="genomes/",
             representative_only=True,
             assembly_level=None,
+            force=False,
+            dry_run=False,
         )
         result = cmd.execute(args)
         assert result == 1
@@ -219,6 +221,8 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 0
@@ -242,6 +246,8 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 0
@@ -263,6 +269,8 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 0
@@ -278,6 +286,8 @@ class TestGenomeDownloadCommand:
             output_dir="genomes/",
             representative_only=True,
             assembly_level=None,
+            force=False,
+            dry_run=False,
         )
         result = cmd.execute(args)
         assert result == 1
@@ -295,9 +305,77 @@ class TestGenomeDownloadCommand:
                 output_dir=tmpdir,
                 representative_only=True,
                 assembly_level=None,
+                force=False,
+                dry_run=False,
             )
             result = cmd.execute(args)
             assert result == 1
+
+    @patch("metaquest.cli.commands.genome.extract_and_organize")
+    @patch("metaquest.cli.commands.genome.download_genomes")
+    def test_execute_skips_present_genome(self, mock_download, mock_extract):
+        cmd = GenomeDownloadCommand()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "GCF_000006945.2.fna").write_text(">seq\nACGT\n")
+            args = argparse.Namespace(
+                accessions=["GCF_000006945.2"],
+                accession_file=None,
+                species=None,
+                genus=None,
+                output_dir=tmpdir,
+                representative_only=True,
+                assembly_level=None,
+                force=False,
+                dry_run=False,
+            )
+            result = cmd.execute(args)
+            assert result == 0
+            mock_download.assert_not_called()
+            mock_extract.assert_not_called()
+
+    @patch("metaquest.cli.commands.genome.extract_and_organize")
+    @patch("metaquest.cli.commands.genome.download_genomes")
+    def test_execute_force_redownloads_present_genome(self, mock_download, mock_extract):
+        mock_download.return_value = Path("genomes/download.zip")
+        mock_extract.return_value = {"GCF_000006945.2": Path("genomes/GCF_000006945.2.fna")}
+        cmd = GenomeDownloadCommand()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "GCF_000006945.2.fna").write_text(">seq\nACGT\n")
+            args = argparse.Namespace(
+                accessions=["GCF_000006945.2"],
+                accession_file=None,
+                species=None,
+                genus=None,
+                output_dir=tmpdir,
+                representative_only=True,
+                assembly_level=None,
+                force=True,
+                dry_run=False,
+            )
+            result = cmd.execute(args)
+            assert result == 0
+            mock_download.assert_called_once()
+
+    @patch("metaquest.cli.commands.genome.extract_and_organize")
+    @patch("metaquest.cli.commands.genome.download_genomes")
+    def test_execute_dry_run_downloads_nothing(self, mock_download, mock_extract):
+        cmd = GenomeDownloadCommand()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "GCF_000006945.2.fna").write_text(">seq\nACGT\n")
+            args = argparse.Namespace(
+                accessions=["GCF_000006945.2", "GCF_000007545.1"],
+                accession_file=None,
+                species=None,
+                genus=None,
+                output_dir=tmpdir,
+                representative_only=True,
+                assembly_level=None,
+                force=False,
+                dry_run=True,
+            )
+            result = cmd.execute(args)
+            assert result == 0
+            mock_download.assert_not_called()
 
 
 class TestGenomePrepareCommand:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -46,6 +46,7 @@ class TestRegisterAllCommands:
             "download_sra",
             "assemble_datasets",
             "status",
+            "extract_target_reads",
             "sra_info",
             "sra_download",
             "sra_stats",

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -45,6 +45,7 @@ class TestRegisterAllCommands:
             "plot_metadata_counts",
             "download_sra",
             "assemble_datasets",
+            "status",
             "sra_info",
             "sra_download",
             "sra_stats",

--- a/tests/test_cli_read_extraction.py
+++ b/tests/test_cli_read_extraction.py
@@ -1,0 +1,112 @@
+"""Tests for the extract_target_reads CLI command."""
+
+import argparse
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from metaquest.cli.commands.read_extraction import ExtractTargetReadsCommand
+
+
+def _args(**kwargs):
+    base = dict(
+        parsed_containment="parsed_containment.txt",
+        genome_id="GCF_1",
+        genome_fasta="GCF_1.fna",
+        fastq_folder="fastq",
+        output_folder="targeted",
+        threshold=0.1,
+        preset="sr",
+        threads=4,
+        assemble=False,
+        min_contig_len=None,
+        dry_run=False,
+    )
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _tree(tmp):
+    root = Path(tmp)
+    table = root / "parsed_containment.txt"
+    table.write_text("\tGCF_1\nSRR1\t0.9\nSRR2\t0.05\n")
+    d = root / "fastq" / "SRR1"
+    d.mkdir(parents=True)
+    (d / "SRR1_1.fastq.gz").write_text("x")
+    (d / "SRR1_2.fastq.gz").write_text("x")
+    genome = root / "GCF_1.fna"
+    genome.write_text(">s\nACGT\n")
+    return root, table, genome
+
+
+class TestExtractTargetReadsCommand:
+    def test_command_properties(self):
+        cmd = ExtractTargetReadsCommand()
+        assert cmd.name == "extract_target_reads"
+        assert "target" in cmd.help.lower()
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_execute_extracts(self, mock_run):
+        cmd = ExtractTargetReadsCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _tree(tmp)
+            rc = cmd.execute(
+                _args(
+                    parsed_containment=str(table),
+                    genome_fasta=str(genome),
+                    fastq_folder=str(root / "fastq"),
+                    output_folder=str(root / "targeted"),
+                    threshold=0.5,
+                )
+            )
+        assert rc == 0
+        assert mock_run.called
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_execute_dry_run(self, mock_run):
+        cmd = ExtractTargetReadsCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _tree(tmp)
+            rc = cmd.execute(
+                _args(
+                    parsed_containment=str(table),
+                    genome_fasta=str(genome),
+                    fastq_folder=str(root / "fastq"),
+                    dry_run=True,
+                )
+            )
+        assert rc == 0
+        mock_run.assert_not_called()
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_execute_with_assembly(self, mock_run):
+        cmd = ExtractTargetReadsCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _tree(tmp)
+            rc = cmd.execute(
+                _args(
+                    parsed_containment=str(table),
+                    genome_fasta=str(genome),
+                    fastq_folder=str(root / "fastq"),
+                    output_folder=str(root / "targeted"),
+                    threshold=0.5,
+                    assemble=True,
+                )
+            )
+        assert rc == 0
+        tools = [c.args[0] for c in mock_run.call_args_list]
+        assert "megahit" in tools
+
+    def test_execute_missing_genome_column_returns_1(self):
+        cmd = ExtractTargetReadsCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _tree(tmp)
+            rc = cmd.execute(
+                _args(
+                    parsed_containment=str(table),
+                    genome_id="GCF_absent",
+                    genome_fasta=str(genome),
+                    fastq_folder=str(root / "fastq"),
+                )
+            )
+        assert rc == 1

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,124 @@
+"""Tests for the `status` (local inventory) CLI command."""
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+from metaquest.cli.commands.status import StatusCommand
+
+
+def _args(**kwargs):
+    base = dict(
+        fastq_folder="fastq",
+        metadata_folder="metadata",
+        genomes_folder="genomes",
+        accessions_file=None,
+        parsed_containment=None,
+        list_missing=False,
+        json=False,
+    )
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _make_tree(tmp):
+    """Create a small fixture tree: one accession fully present, one absent."""
+    root = Path(tmp)
+    (root / "fastq" / "SRR1").mkdir(parents=True)
+    (root / "fastq" / "SRR1" / "SRR1.fastq.gz").write_text("@r\nACGT\n+\nIIII\n")
+    (root / "metadata").mkdir()
+    (root / "metadata" / "SRR1_metadata.xml").write_text("<xml/>")
+    (root / "genomes").mkdir()
+    (root / "genomes" / "GCF_000006945.2.fna").write_text(">s\nACGT\n")
+    return root
+
+
+class TestStatusCommand:
+    def test_command_properties(self):
+        cmd = StatusCommand()
+        assert cmd.name == "status"
+        assert "local" in cmd.help.lower()
+
+    def test_on_disk_inventory(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                )
+            )
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "FASTQ accessions on disk : 1" in out
+        assert "Metadata XML on disk     : 1" in out
+        assert "Genome FASTA on disk     : 1" in out
+
+    def test_reconcile_present_and_missing(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            accs = root / "accs.txt"
+            accs.write_text("SRR1\nSRR2\n")
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                    accessions_file=str(accs),
+                    list_missing=True,
+                )
+            )
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "FASTQ    : 1 present, 1 missing" in out
+        assert "Metadata : 1 present, 1 missing" in out
+        assert "SRR2" in out
+
+    def test_json_output(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            accs = root / "accs.txt"
+            accs.write_text("SRR1\nSRR2\n")
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                    accessions_file=str(accs),
+                    json=True,
+                )
+            )
+        assert result == 0
+        report = json.loads(capsys.readouterr().out)
+        assert report["on_disk"]["fastq_accessions"] == 1
+        assert report["wanted"]["total"] == 2
+        assert report["wanted"]["fastq_missing"] == ["SRR2"]
+
+    def test_parsed_containment_supplies_wanted_list(self, capsys):
+        cmd = StatusCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_tree(tmp)
+            table = root / "parsed_containment.txt"
+            table.write_text("accession\tGCF_x\nSRR1\t0.9\nSRR2\t0.4\n")
+            result = cmd.execute(
+                _args(
+                    fastq_folder=str(root / "fastq"),
+                    metadata_folder=str(root / "metadata"),
+                    genomes_folder=str(root / "genomes"),
+                    parsed_containment=str(table),
+                    json=True,
+                )
+            )
+        assert result == 0
+        report = json.loads(capsys.readouterr().out)
+        assert report["wanted"]["total"] == 2
+
+    def test_missing_accessions_file_errors(self):
+        cmd = StatusCommand()
+        result = cmd.execute(_args(accessions_file="/nonexistent/accs.txt"))
+        assert result == 1

--- a/tests/test_read_extraction.py
+++ b/tests/test_read_extraction.py
@@ -1,0 +1,144 @@
+"""Tests for targeted read extraction (metaquest.data.read_extraction)."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from metaquest.core.exceptions import DataAccessError, ProcessingError
+from metaquest.data.read_extraction import (
+    assemble_extracted_reads,
+    extract_target_reads,
+    select_samples_for_genome,
+)
+
+
+def _make_tree(tmp, paired=True):
+    """Build a fixture: containment table, per-accession FASTQ, and a genome FASTA."""
+    root = Path(tmp)
+    table = root / "parsed_containment.txt"
+    table.write_text(
+        "\tGCF_1\tGCF_2\tmax_containment\n"
+        "SRR1\t0.90\t0.0\t0.90\n"
+        "SRR2\t0.40\t0.85\t0.85\n"
+        "SRR3\t0.05\t0.0\t0.05\n"
+    )
+    for acc in ("SRR1", "SRR2", "SRR3"):
+        d = root / "fastq" / acc
+        d.mkdir(parents=True)
+        (d / f"{acc}_1.fastq.gz").write_text("x")
+        if paired:
+            (d / f"{acc}_2.fastq.gz").write_text("x")
+    genome = root / "GCF_1.fna"
+    genome.write_text(">s\nACGT\n")
+    return root, table, genome
+
+
+class TestSelectSamples:
+    def test_threshold_selection(self):
+        df = pd.DataFrame({"GCF_1": [0.9, 0.4, 0.05]}, index=["SRR1", "SRR2", "SRR3"])
+        assert select_samples_for_genome(df, "GCF_1", 0.5) == ["SRR1"]
+        assert select_samples_for_genome(df, "GCF_1", 0.3) == ["SRR1", "SRR2"]
+
+    def test_missing_genome_column(self):
+        df = pd.DataFrame({"GCF_1": [0.9]}, index=["SRR1"])
+        with pytest.raises(ProcessingError):
+            select_samples_for_genome(df, "GCF_missing", 0.1)
+
+
+class TestExtractTargetReads:
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_paired_extraction_command_construction(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _make_tree(tmp, paired=True)
+            results = extract_target_reads(
+                parsed_containment=table,
+                genome_id="GCF_1",
+                genome_fasta=genome,
+                fastq_folder=root / "fastq",
+                output_folder=root / "targeted",
+                threshold=0.5,
+            )
+        # Only SRR1 clears threshold 0.5 for GCF_1.
+        assert list(results) == ["SRR1"]
+        assert [str(p.name) for p in results["SRR1"]] == ["GCF_1_1.fastq.gz", "GCF_1_2.fastq.gz"]
+
+        tools = [c.args[0] for c in mock_run.call_args_list]
+        assert tools == ["minimap2", "samtools", "samtools"]
+        # samtools fastq for paired input uses -1/-2.
+        fastq_args = mock_run.call_args_list[2].args[1]
+        assert "-1" in fastq_args and "-2" in fastq_args
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_single_end_uses_flag_0(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _make_tree(tmp, paired=False)
+            results = extract_target_reads(
+                parsed_containment=table,
+                genome_id="GCF_1",
+                genome_fasta=genome,
+                fastq_folder=root / "fastq",
+                output_folder=root / "targeted",
+                threshold=0.5,
+            )
+        assert [p.name for p in results["SRR1"]] == ["GCF_1.fastq.gz"]
+        fastq_args = mock_run.call_args_list[2].args[1]
+        assert "-0" in fastq_args
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_dry_run_runs_no_tools(self, mock_run):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _make_tree(tmp)
+            results = extract_target_reads(
+                parsed_containment=table,
+                genome_id="GCF_1",
+                genome_fasta=genome,
+                fastq_folder=root / "fastq",
+                output_folder=root / "targeted",
+                threshold=0.3,
+                dry_run=True,
+            )
+        assert set(results) == {"SRR1", "SRR2"}
+        mock_run.assert_not_called()
+
+    def test_missing_table_raises(self):
+        with pytest.raises(DataAccessError):
+            extract_target_reads("/no/such/table.txt", "GCF_1", "/no/genome.fna")
+
+    def test_bad_preset_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _make_tree(tmp)
+            with pytest.raises(ProcessingError):
+                extract_target_reads(table, "GCF_1", genome, preset="not-a-preset")
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_missing_genome_fasta_raises(self, mock_run):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, _ = _make_tree(tmp)
+            with pytest.raises(DataAccessError):
+                extract_target_reads(table, "GCF_1", root / "absent.fna", fastq_folder=root / "fastq")
+
+
+class TestAssembleExtractedReads:
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_paired_uses_1_2(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        out = assemble_extracted_reads([Path("a_1.fastq.gz"), Path("a_2.fastq.gz")], "asm")
+        assert out == Path("asm")
+        args = mock_run.call_args.args[1]
+        assert "-1" in args and "-2" in args and "-r" not in args
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_single_uses_r(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        assemble_extracted_reads([Path("a.fastq.gz")], "asm", min_contig_len=500)
+        args = mock_run.call_args.args[1]
+        assert "-r" in args and "--min-contig-len" in args
+
+    def test_bad_read_count_raises(self):
+        with pytest.raises(ProcessingError):
+            assemble_extracted_reads([], "asm")


### PR DESCRIPTION
## Summary

Phase 3 (stacked on #37). Answers the question "what tools do we have to filter target reads before assembly": previously none, so this adds a map-and-extract step for a small, targeted assembly rather than a whole-metagenome one.

- **Allowlist minimap2 + samtools** in `ALLOWED_BIOINFORMATICS_TOOLS` (plus megahit `-r` for single-end). `SecureSubprocess` derives its allowlist from this dict, so no other security change is needed. (`seqtk` was intentionally not added — it would be unused.)
- **`data/read_extraction.py`**: `extract_target_reads()` selects samples from the parsed containment table above `--threshold`, maps each sample's reads with minimap2, keeps mapped reads with `samtools view -F 4`, and exports them with `samtools fastq` to `targeted/<ACC>/`. Paired input yields `_1`/`_2` files, single-end one file. `assemble_extracted_reads()` runs megahit on the reduced set.
- **`extract_target_reads` CLI command** with `--threshold`, `--preset` (sr / map-ont / map-pb / map-hifi), `--dry-run`, and `--assemble`.
- **Fix `_find_paired_reads`** to also match fasterq-dump's `_1`/`_2` split-files naming (previously only `R1`/`R2`).

## Testing

- New `tests/test_read_extraction.py` and `tests/test_cli_read_extraction.py` mock `SecureSubprocess.run_secure` (the established pattern) to assert minimap2/samtools/megahit command construction, threshold selection, paired vs single-end handling, dry-run, and error paths.
- Full suite green (1227 passed); `make check` clean.

## Note on real runs

The real minimap2/samtools/megahit invocations need those tools installed and are not exercised in CI (they shell out). A one-line manual test: `metaquest extract_target_reads --parsed-containment parsed_containment.txt --genome-id <GCF> --genome-fasta genomes/<GCF>.fna --threshold 0.5`.

Base is `feat/local-inventory`; GitHub will retarget down the stack as #36/#37 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)