### PR TITLE
Default megahit assembly to single-thread on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ type (`sr` for Illumina, `map-ont`/`map-pb`/`map-hifi` for long reads), and `--a
 megahit on each sample's extracted reads. This step requires `minimap2`, `samtools`, and (for
 `--assemble`) `megahit` to be installed and on the PATH.
 
+On macOS the assembly defaults to a single thread, because megahit 1.2.9's parallel k-mer sorting step
+is unstable on recent macOS releases (mapping with minimap2/samtools still uses `--threads`). Override
+the assembly thread count explicitly with `--assembly-threads` if your megahit build handles more.
+
 ## Advanced SRA Operations
 
 ### Which SRA download command should I use?

--- a/metaquest/cli/commands/read_extraction.py
+++ b/metaquest/cli/commands/read_extraction.py
@@ -9,6 +9,7 @@ from metaquest.data.read_extraction import (
     MINIMAP2_PRESETS,
     assemble_extracted_reads,
     extract_target_reads,
+    resolve_assembly_threads,
 )
 
 
@@ -43,6 +44,12 @@ class ExtractTargetReadsCommand(BaseCommand):
         parser.add_argument(
             "--assemble", action="store_true", help="Assemble each sample's extracted reads with megahit"
         )
+        parser.add_argument(
+            "--assembly-threads",
+            type=int,
+            default=None,
+            help="Threads for the megahit assembly (defaults to 1 on macOS, --threads elsewhere)",
+        )
         parser.add_argument("--min-contig-len", type=int, default=None, help="megahit minimum contig length")
         parser.add_argument(
             "--dry-run", action="store_true", help="List the qualifying samples without running any tool"
@@ -71,11 +78,17 @@ class ExtractTargetReadsCommand(BaseCommand):
             self.logger.info("Extracted reads for %d sample(s)", len(results))
 
             if args.assemble:
+                asm_threads = resolve_assembly_threads(args.assembly_threads, args.threads)
+                if args.assembly_threads is None and asm_threads < args.threads:
+                    self.logger.info(
+                        "Running megahit single-threaded on macOS (its parallel sort is unstable here); "
+                        "override with --assembly-threads"
+                    )
                 for accession, reads in results.items():
                     if not reads:
                         continue
                     out_dir = Path(args.output_folder) / accession / f"{args.genome_id}_assembly"
-                    assemble_extracted_reads(reads, out_dir, threads=args.threads, min_contig_len=args.min_contig_len)
+                    assemble_extracted_reads(reads, out_dir, threads=asm_threads, min_contig_len=args.min_contig_len)
                 self.logger.info("Assembled %d sample(s)", len(results))
 
             return 0

--- a/metaquest/data/read_extraction.py
+++ b/metaquest/data/read_extraction.py
@@ -11,6 +11,7 @@ to filter and export the mapped reads. External tools run through
 """
 
 import logging
+import platform
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -170,6 +171,28 @@ def extract_target_reads(
         logger.info("Extracted mapped reads for %s -> %s", accession, ", ".join(str(p) for p in written))
 
     return results
+
+
+def resolve_assembly_threads(requested: Optional[int], fallback: int) -> int:
+    """Pick the megahit thread count, defaulting to single-thread on macOS.
+
+    megahit 1.2.9's multithreaded k-mer sorting step segfaults on recent macOS
+    (the prebuilt binary predates the current runtime), so when the user has not
+    asked for a specific value we cap the assembly at one thread on Darwin.
+    minimap2/samtools are unaffected and keep using ``fallback`` threads.
+
+    Args:
+        requested: An explicit thread count from the user, or None for the default.
+        fallback: The thread count to use when no override is given (non-macOS).
+
+    Returns:
+        The number of threads to run megahit with.
+    """
+    if requested is not None:
+        return requested
+    if platform.system() == "Darwin":
+        return 1
+    return fallback
 
 
 def assemble_extracted_reads(

--- a/tests/test_cli_read_extraction.py
+++ b/tests/test_cli_read_extraction.py
@@ -19,6 +19,7 @@ def _args(**kwargs):
         preset="sr",
         threads=4,
         assemble=False,
+        assembly_threads=None,
         min_contig_len=None,
         dry_run=False,
     )
@@ -96,6 +97,51 @@ class TestExtractTargetReadsCommand:
         assert rc == 0
         tools = [c.args[0] for c in mock_run.call_args_list]
         assert "megahit" in tools
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_assembly_single_thread_on_macos(self, mock_run, monkeypatch):
+        monkeypatch.setattr("metaquest.data.read_extraction.platform.system", lambda: "Darwin")
+        cmd = ExtractTargetReadsCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _tree(tmp)
+            rc = cmd.execute(
+                _args(
+                    parsed_containment=str(table),
+                    genome_fasta=str(genome),
+                    fastq_folder=str(root / "fastq"),
+                    output_folder=str(root / "targeted"),
+                    threshold=0.5,
+                    threads=4,
+                    assemble=True,
+                )
+            )
+        assert rc == 0
+        megahit_call = next(c for c in mock_run.call_args_list if c.args[0] == "megahit")
+        args = megahit_call.args[1]
+        assert args[args.index("--num-cpu-threads") + 1] == "1"
+
+    @patch("metaquest.data.read_extraction.SecureSubprocess.run_secure")
+    def test_assembly_threads_override_on_macos(self, mock_run, monkeypatch):
+        monkeypatch.setattr("metaquest.data.read_extraction.platform.system", lambda: "Darwin")
+        cmd = ExtractTargetReadsCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            root, table, genome = _tree(tmp)
+            rc = cmd.execute(
+                _args(
+                    parsed_containment=str(table),
+                    genome_fasta=str(genome),
+                    fastq_folder=str(root / "fastq"),
+                    output_folder=str(root / "targeted"),
+                    threshold=0.5,
+                    threads=4,
+                    assemble=True,
+                    assembly_threads=6,
+                )
+            )
+        assert rc == 0
+        megahit_call = next(c for c in mock_run.call_args_list if c.args[0] == "megahit")
+        args = megahit_call.args[1]
+        assert args[args.index("--num-cpu-threads") + 1] == "6"
 
     def test_execute_missing_genome_column_returns_1(self):
         cmd = ExtractTargetReadsCommand()

--- a/tests/test_read_extraction.py
+++ b/tests/test_read_extraction.py
@@ -11,6 +11,7 @@ from metaquest.core.exceptions import DataAccessError, ProcessingError
 from metaquest.data.read_extraction import (
     assemble_extracted_reads,
     extract_target_reads,
+    resolve_assembly_threads,
     select_samples_for_genome,
 )
 
@@ -142,3 +143,17 @@ class TestAssembleExtractedReads:
     def test_bad_read_count_raises(self):
         with pytest.raises(ProcessingError):
             assemble_extracted_reads([], "asm")
+
+
+class TestResolveAssemblyThreads:
+    def test_explicit_request_wins(self, monkeypatch):
+        monkeypatch.setattr("metaquest.data.read_extraction.platform.system", lambda: "Darwin")
+        assert resolve_assembly_threads(8, 4) == 8
+
+    def test_macos_defaults_to_single_thread(self, monkeypatch):
+        monkeypatch.setattr("metaquest.data.read_extraction.platform.system", lambda: "Darwin")
+        assert resolve_assembly_threads(None, 4) == 1
+
+    def test_non_macos_uses_fallback(self, monkeypatch):
+        monkeypatch.setattr("metaquest.data.read_extraction.platform.system", lambda: "Linux")
+        assert resolve_assembly_threads(None, 4) == 4


### PR DESCRIPTION
## Summary

The `extract_target_reads --assemble` step could segfault on macOS. Root cause: **megahit 1.2.9's multithreaded k-mer sorting step segfaults on recent macOS** (the 2019 prebuilt binary predates the current OS runtime) — reproduced with both the native osx-arm64 and osx-64 builds, at any input size, regardless of memory. Running megahit single-threaded (`-t 1`) completes normally. It "used to work" because the megahit binary is unchanged; the macOS upgrade broke its parallel sort.

## Change

- `resolve_assembly_threads(requested, fallback)` in `data/read_extraction.py`: returns the explicit value if given, else **1 on macOS** (`platform.system() == "Darwin"`), else `fallback`.
- The `extract_target_reads` CLI resolves assembly threads through it and logs a one-line notice when it caps to 1. minimap2/samtools are unaffected and keep using `--threads`.
- New `--assembly-threads` flag to override on any platform.
- README note on the macOS default.

## Testing

- Unit tests for `resolve_assembly_threads` (explicit / macOS / non-macOS) and CLI tests asserting megahit is invoked with `--num-cpu-threads 1` on macOS and the override is honored (`platform.system` patched).
- Full suite green (1232 passed); `make check` clean.
- **Real-data check on macOS 26.2 / M3:** `extract_target_reads --assemble --threads 4` now logs "Running megahit single-threaded on macOS" and assembles the real Salmonella-mapping reads (5 contigs) instead of segfaulting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)